### PR TITLE
Recover from a Paperwallet

### DIFF
--- a/wallet/src/blockchain.rs
+++ b/wallet/src/blockchain.rs
@@ -14,7 +14,7 @@ impl Settings {
         let ledger = Ledger::new(header_id, block.contents.iter())?;
 
         let static_parameters = ledger.get_static_parameters().clone();
-        let parameters = ledger.get_ledger_parameters().clone();
+        let parameters = ledger.get_ledger_parameters();
 
         Ok(Self {
             static_parameters,

--- a/wallet/src/recovering/daedalus.rs
+++ b/wallet/src/recovering/daedalus.rs
@@ -46,7 +46,7 @@ impl RecoveringDaedalus {
             if let Fragment::OldUtxoDeclaration(utxos) = fragment {
                 for (output_index, (address, value)) in utxos.addrs.iter().enumerate() {
                     let pointer = UtxoPointer {
-                        transaction_id: fragment_id.clone(),
+                        transaction_id: fragment_id,
                         output_index: output_index as u8,
                         value: *value,
                     };

--- a/wallet/src/recovering/icarus.rs
+++ b/wallet/src/recovering/icarus.rs
@@ -107,7 +107,7 @@ impl RecoveringIcarus {
 
     fn populate_first_account(&mut self) {
         let account_id = HardDerivation::min_value();
-        let account = self.wallet.create_account(account_id).clone();
+        let account = self.wallet.create_account(account_id);
 
         let account = RecoveringAccount::new(account_id, account);
         self.accounts.push(account);
@@ -121,7 +121,7 @@ impl RecoveringIcarus {
             .id;
 
         if let Some(id) = last_id.checked_add(1) {
-            let account = self.wallet.create_account(id).clone();
+            let account = self.wallet.create_account(id);
             let account = RecoveringAccount::new(id, account);
             self.accounts.push(account);
         } else {
@@ -161,7 +161,7 @@ impl RecoveringIcarus {
             if let Fragment::OldUtxoDeclaration(utxos) = fragment {
                 for (output_index, (address, value)) in utxos.addrs.iter().enumerate() {
                     let pointer = UtxoPointer {
-                        transaction_id: fragment_id.clone(),
+                        transaction_id: fragment_id,
                         output_index: output_index as u8,
                         value: *value,
                     };

--- a/wallet/src/recovering/mod.rs
+++ b/wallet/src/recovering/mod.rs
@@ -3,6 +3,7 @@
 mod daedalus;
 mod dump;
 mod icarus;
+mod paperwallet;
 
 use crate::{keygen, Password, Wallet};
 use chain_path_derivation::{
@@ -34,6 +35,20 @@ pub struct RecoveryBuilder {
 impl RecoveryBuilder {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// instead of recovering from mnemonics, here we recover from the Daedalus paperwallet
+    ///
+    pub fn paperwallet(
+        self,
+        password: impl AsRef<[u8]>,
+        input: impl AsRef<[u8]>,
+    ) -> Result<Self, bip39::Error> {
+        let entropy = paperwallet::unscramble(password.as_ref(), input.as_ref());
+
+        let entropy = bip39::Entropy::from_slice(&entropy)?;
+
+        Ok(self.entropy(entropy))
     }
 
     pub fn mnemonics<D>(self, dic: &D, mnemonics: impl AsRef<str>) -> Result<Self, bip39::Error>

--- a/wallet/src/recovering/mod.rs
+++ b/wallet/src/recovering/mod.rs
@@ -58,10 +58,7 @@ impl RecoveryBuilder {
         let mnemonics = bip39::Mnemonics::from_string(dic, mnemonics.as_ref())?;
         let entropy = bip39::Entropy::from_mnemonics(&mnemonics)?;
 
-        Ok(Self {
-            entropy: Some(entropy),
-            ..self
-        })
+        Ok(self.entropy(entropy))
     }
 
     pub fn entropy(self, entropy: bip39::Entropy) -> Self {

--- a/wallet/src/recovering/mod.rs
+++ b/wallet/src/recovering/mod.rs
@@ -177,8 +177,7 @@ fn from_bip39_entropy(
     keygen::generate_seed(&entropy, password.as_ref(), &mut seed);
     let xprv = XPrv::normalize_bytes_force3rd(seed);
 
-    let key = Key::new_unchecked(xprv, Default::default(), derivation_scheme);
-    key
+    Key::new_unchecked(xprv, Default::default(), derivation_scheme)
 }
 
 /// for some unknown design reasons Daedalus seeds are encoded in cbor

--- a/wallet/src/recovering/paperwallet.rs
+++ b/wallet/src/recovering/paperwallet.rs
@@ -1,0 +1,124 @@
+use cryptoxide::hmac::Hmac;
+use cryptoxide::pbkdf2::pbkdf2;
+use cryptoxide::sha2::Sha512;
+
+const ITERS: u32 = 10000;
+pub const IV_SIZE: usize = 8;
+const SALT_SIZE: usize = IV_SIZE;
+
+fn gen(iv: &[u8], password: &[u8], buf: &mut [u8]) {
+    assert!(iv.len() == IV_SIZE);
+    let mut salt = [0u8; SALT_SIZE];
+    salt[0..IV_SIZE].copy_from_slice(iv);
+    let mut mac = Hmac::new(Sha512::new(), password);
+    pbkdf2(&mut mac, &salt[..], ITERS, buf);
+}
+
+/// Given a 4 bytes IV, and a password, scramble the input
+/// using a simple XOR, and returning the IV prepended to the shielded input
+#[cfg(test)]
+fn scramble(iv: &[u8], password: &[u8], input: &[u8]) -> Vec<u8> {
+    assert!(iv.len() == IV_SIZE);
+    let sz = IV_SIZE + input.len();
+    let mut out = vec![0; sz];
+
+    out[..IV_SIZE].copy_from_slice(iv);
+    gen(iv, password, &mut out[IV_SIZE..sz]);
+
+    for i in IV_SIZE..sz {
+        out[i] ^= input[i - IV_SIZE];
+    }
+    out
+}
+
+/// Try to reverse the scramble operation, using
+/// the first `IV_SIZE` bytes as IV, and the rest as the shielded input.
+pub fn unscramble(password: &[u8], input: &[u8]) -> Vec<u8> {
+    assert!(input.len() > IV_SIZE);
+
+    let out_sz = input.len() - IV_SIZE;
+
+    let mut out = vec![0; out_sz];
+
+    gen(&input[0..IV_SIZE], password, &mut out[0..out_sz]);
+    for i in 0..out_sz {
+        out[i] ^= input[IV_SIZE + i];
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    //use paperwallet::{scramble,unscramble};
+    use crate::recovering::paperwallet;
+
+    /// # GOLDEN_TEST: cardano/crypto/scramble128
+    ///
+    ///
+    ///
+    /// ## Input(s)
+    ///
+    /// ```text
+    /// iv ([u8,4]) = "hexadecimal encoded bytes"
+    /// input (&'static str) = "UTF8 BIP39 passphrase (english)"
+    /// passphrase (&'static str) = "Bouble quoted, encoded string."
+    /// ```
+    ///
+    /// ## Output(s)
+    ///
+    /// ```text
+    /// shielded_input (&'static str) = "UTF8 BIP39 passphrase (english)"
+    /// ```
+    struct TestVector {
+        iv: [u8; 8],
+        input: [u8; 16],
+        passphrase: &'static str,
+        shielded_input: [u8; 24],
+    }
+
+    const GOLDEN_TESTS : [TestVector;3] =
+  [ TestVector
+    { iv : [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+    , input : [0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f]
+    , passphrase : ""
+    , shielded_input : [0, 0, 0, 0, 0, 0, 0, 0, 250, 194, 41, 40, 102, 196, 34, 60, 90, 125, 175, 186, 222, 152, 14, 9]
+    }
+  , TestVector
+    { iv : [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
+    , input : [0x5a, 0x94, 0x0d, 0x50, 0xab, 0x0d, 0x4e, 0x2e, 0xbf, 0x3b, 0x2c, 0x6e, 0xb3, 0x99, 0xe8, 0x27]
+    , passphrase : "Cardano Ada"
+    , shielded_input : [0, 1, 2, 3, 4, 5, 6, 7, 193, 34, 111, 15, 127, 245, 15, 164, 3, 24, 171, 35, 99, 32, 181, 158]
+    }
+  , TestVector
+    { iv : [0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x2a]
+    , input : [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]
+    , passphrase : "This is a very long passphrase. This is a very long passphrase. This is a very long passphrase. This is a very long passphrase."
+    , shielded_input : [42, 42, 42, 42, 42, 42, 42, 42, 199, 113, 24, 116, 236, 196, 179, 147, 0, 136, 72, 43, 59, 108, 139, 133]
+    }
+  ];
+
+    #[test]
+    fn paper_scramble() {
+        for tv in GOLDEN_TESTS.iter() {
+            let r = paperwallet::scramble(&tv.iv[..], tv.passphrase.as_bytes(), &tv.input[..]);
+            assert_eq!(
+                &r[..],
+                &tv.shielded_input[..],
+                "scramble(iv: {iv}, password: {password}, input: {input}): {output} != {expected}",
+                iv = hex::encode(&tv.iv),
+                password = tv.passphrase,
+                input = hex::encode(&tv.input),
+                output = hex::encode(&r),
+                expected = hex::encode(&tv.shielded_input),
+            );
+        }
+    }
+
+    #[test]
+    fn paper_unscramble() {
+        for tv in GOLDEN_TESTS.iter() {
+            let r = paperwallet::unscramble(tv.passphrase.as_bytes(), &tv.shielded_input[..]);
+            assert_eq!(&r[..], &tv.input[..]);
+        }
+    }
+}


### PR DESCRIPTION
add support for paper wallet. We don't yet enforce recovering from the daedalus paper wallet mnemonics as this is a wallet choice more than a technically sounds decision

relates to #4 