### PR TITLE
Add release wasm job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,3 +118,43 @@ jobs:
           tag: ${{ github.ref }}
           file_glob: true
           overwrite: true
+
+  release_wasm:
+    name: Release wasm assets
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [nodejs, web]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install wasm pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: build
+        run: wasm-pack build --release --target ${{ matrix.target }} wallet-js
+
+      - name: pack
+        run: wasm-pack pack ./wallet-js
+
+      - name: Get tag version
+        id: get_version
+        run: echo ::set-output name=VERSION::``${GITHUB_REF#refs/tags/}``
+        shell: bash
+
+      - name: rename-tarball
+        run: find ./wallet-js/pkg -name wallet-js*.tgz -exec mv {} chain-wallet-libs-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target }}.tgz \;
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: chain-wallet-libs-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target }}.*
+          asset_name: chain-wallet-libs-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target }}
+          tag: ${{ github.ref }}
+          file_glob: true
+          overwrite: true

--- a/wallet-js/Cargo.toml
+++ b/wallet-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet-js"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Enzo Cioppettini <ecioppettini@atixlabs.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Add `chain-wallet-libs-{version}-web.tgz` and `chain-wallet-libs-{version}-nodejs.tgz` to the release. These are npm packages, which can be installed with `npm install`.

This would be the 3rd item in #15 

Also change the wallet-js crate version to `0.2.0`. I'm not completely sure about this part, I guess we want all the subcrates to have the same version?