### PR TITLE
fix allocation bug in jni binding

### DIFF
--- a/bindings/wallet-jni/src/lib.rs
+++ b/bindings/wallet-jni/src/lib.rs
@@ -77,7 +77,7 @@ pub extern "system" fn Java_com_iohk_jormungandrwallet_Wallet_initialFunds(
     let len = env
         .get_array_length(block0)
         .expect("Couldn't get block0 array length") as usize;
-    let mut bytes = Vec::with_capacity(len as usize);
+    let mut bytes = vec![0i8; len as usize];
     env.get_byte_array_region(block0, 0, &mut bytes);
     if wallet_ptr != null_mut() {
         wallet_retrieve_funds(wallet_ptr, bytes.as_ptr() as *const u8, len, settings_ptr);


### PR DESCRIPTION
EDIT: `with_capacity` doesn't set the `len` of the vec. And `get_byte_array_region` copies `buf.len()` elements. So even if `with_capacity` does allocate the memory, the buffer passed to the function has a length of 0. (And doesn't copy anything)

By the way, I think it should be possible to write a few tests in java (not android, just a normal jvm java binary) for this little things. Although, on the other hand, we would probably like to test this on the android tests, in which case it wouldn't really add that much. What do you think? @NicolasDP @danielSanchezQ 