### PR TITLE
Add wallet cordova build jni script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -289,7 +289,7 @@ jobs:
         working-directory: ./bindings/wallet-cordova/src/android/libs
         run: mv i686-linux-android x86 
 
-      - name: rename amd64-v8a 
+      - name: rename x86_64
         working-directory: ./bindings/wallet-cordova/src/android/libs
         run: mv x86_64-linux-android x86_64 
 

--- a/bindings/wallet-cordova/BUILD.md
+++ b/bindings/wallet-cordova/BUILD.md
@@ -1,0 +1,19 @@
+# Building the plugin
+
+Before packaging the plugin, it's necessary to build some native libraries from the rust crates in this repo, and copy the files inside the plugin's directory.
+
+## Android
+
+For android, run `build_jni.py` in the plugin's root directory. This assumes a proper configuration to cross-compile rust to the android targets. Besides this, as a requirement to build the `clear_on_drop` dependency, a working C compiler for the target platform is needed. This can be configured, with, for example:
+
+```
+export CC_aarch64_linux_android=$NDK/toolchains/llvm/prebuilt/$BUILDING_PLATFORM/bin/aarch64-linux-android28-clang
+
+export CC_armv7_linux_androideabi=$NDK/toolchains/llvm/prebuilt/$BUILDING_PLATFORM/bin/armv7a-linux-androideabi28-clang
+
+export CC_i686_linux_android=$NDK/toolchains/llvm/prebuilt/$BUILDING_PLATFORM/bin/i686-linux-android28-clang
+
+export CC_x86_64_linux_android=$NDK/toolchains/llvm/prebuilt/$BUILDING_PLATFORM/bin/x86_64-linux-android28-clang
+```
+
+Where $NDK is your * Android NDK * installation directory, and $BUILDING_PLATFORM is your current platform (not the target).

--- a/bindings/wallet-cordova/build_jni.py
+++ b/bindings/wallet-cordova/build_jni.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import subprocess
+import sys
+import shutil
+
+libname = "libwallet_jni.so"
+copy_to = Path("src/android/libs");
+root_directory = Path("../../target/") 
+
+targets = {
+    "aarch64-linux-android" : "amd64-v8a",
+    "armv7-linux-androideabi" : "armeabi-v7a",
+    "i686-linux-android" : "x86",
+    "x86_64-linux-android" : "x86_64",
+}
+
+def run():
+    for rust_target, android_target in targets.items():
+        out = subprocess.run(["cargo", "rustc", "--release", "--target", rust_target, "-p" "wallet-jni", "--", "-C", "lto"])
+
+        if out.returncode != 0:
+            print("couldn't build for target: ", rust_target)
+            sys.exit(1)
+
+        dst = (copy_to / android_target)
+        dst.mkdir(parents=True, exist_ok=True);
+
+        src = root_directory / rust_target / "release" / libname
+        shutil.copy(src, dst)
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Add python (3) script for building the jni and copy the files from the root's target directory to the proper directory inside the plugin.

The script assumes that's been run from the directory it is in (as the paths are relative).

relates to #31 