### PR TITLE
Add electron plugin impl

### DIFF
--- a/bindings/wallet-cordova/.gitignore
+++ b/bindings/wallet-cordova/.gitignore
@@ -10,4 +10,7 @@ Thumbs.db
 *.swp
 *.user
 
+src/electron/pkg
+src/android/libs
+
 node_modules

--- a/bindings/wallet-cordova/BUILD.md
+++ b/bindings/wallet-cordova/BUILD.md
@@ -17,3 +17,11 @@ export CC_x86_64_linux_android=$NDK/toolchains/llvm/prebuilt/$BUILDING_PLATFORM/
 ```
 
 Where $NDK is your * Android NDK * installation directory, and $BUILDING_PLATFORM is your current platform (not the target).
+
+# Electron
+
+## Requirements
+
+wasm-pack (TODO: Add some link)
+
+run `build_wasm.py` in the plugin's root directory.

--- a/bindings/wallet-cordova/README.md
+++ b/bindings/wallet-cordova/README.md
@@ -1,22 +1,16 @@
 # README
 
-## Testing
+# Usage
 
-The tests use [cordova-plugin-test-framework](https://github.com/apache/cordova-plugin-test-framework).
+*TODO* : the js API could use some tweaks, best to add examples then
 
-** TLDR ** (for android)
+## Example
 
-```sh
-cd $TEST_APP_DIRECTORY 
-cordova create hello com.example.hello HelloWorld
-cd hello
-cordova platform add android 
-cordova plugin add cordova-plugin-test-framework
-cordova plugin add this-plugin-path
-cordova plugin add path-to-wallet-cordova/tests
-sed 's/<content src="index.html" \/>/<content src="cdvtests\/index.html" \/>/' config.xml -i
-cordova build
-cordova run android
+```js
+
+// TODO: 
 ```
 
-Where `this-plugin-path` could be the packaged version, or the path to the root directory.
+# Electron quirks
+
+At the moment, the plugin requires that node integrations are enabled in the app.

--- a/bindings/wallet-cordova/TESTING.md
+++ b/bindings/wallet-cordova/TESTING.md
@@ -1,0 +1,26 @@
+# Testing
+
+The tests use [cordova-plugin-test-framework](https://github.com/apache/cordova-plugin-test-framework).
+
+# Android
+
+## TLDR
+
+```sh
+cd $TEST_APP_DIRECTORY 
+cordova create hello com.example.hello HelloWorld
+cd hello
+cordova platform add android 
+cordova plugin add cordova-plugin-test-framework
+cordova plugin add this-plugin-path
+cordova plugin add path-to-wallet-cordova/tests
+sed 's/<content src="index.html" \/>/<content src="cdvtests\/index.html" \/>/' config.xml -i
+cordova build
+cordova run android
+```
+
+Where `this-plugin-path` could be the packaged version, or the path to the root directory.
+
+# Electron
+
+Currently the tests don't work for some reason

--- a/bindings/wallet-cordova/build_wasm.py
+++ b/bindings/wallet-cordova/build_wasm.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import subprocess
+import sys
+import shutil
+
+
+def run():
+    wallet_js = Path("../wallet-js")
+    relative_path_from_wallet_js = Path("../wallet-cordova/src/electron/pkg")
+    out = subprocess.run(["wasm-pack", "build", "--target",
+                          "no-modules", "-d", relative_path_from_wallet_js, wallet_js])
+
+    if out.returncode != 0:
+        print("couldn't build js bindings ")
+        sys.exit(1)
+
+    # the output of 'no-modules' target generates a umd-style module, this means it adds a 'wasm_bindgen' variable to the global namespace
+    # when we source the file by using the <js-module> cordova plugin directive, it is automagically wrapped with a cordova amd-style module
+    # we append the custom export of the 'global' (but it is not global, because of the wrap) in order to be able to use `cordova.require`
+    with open(Path("src/electron/pkg/wallet_js.js"), "a") as file_object:
+        file_object.write("\nmodule.exports = wasm_bindgen")
+
+
+if __name__ == "__main__":
+    run()

--- a/bindings/wallet-cordova/plugin.xml
+++ b/bindings/wallet-cordova/plugin.xml
@@ -33,6 +33,19 @@
         <source-file src="src/android/libs/armeabi-v7a/libwallet_jni.so" target-dir="libs/armeabi-v7a" />
     </platform>
 
+    <platform name="electron">
+        <config-file target="config.xml" parent="/*">
+            <feature name="WalletPlugin">
+                <param name="electron-package" value="WalletPlugin" />
+            </feature>
+        </config-file>
+
+
+        <js-module src="src/electron/walletProxy.js" name="WalletProxy">
+            <runs />
+        </js-module>
+    </platform>
+
     <!-- ios -->
     <!-- just as example -->
     <platform name="ios">

--- a/bindings/wallet-cordova/plugin.xml
+++ b/bindings/wallet-cordova/plugin.xml
@@ -44,6 +44,11 @@
         <js-module src="src/electron/walletProxy.js" name="WalletProxy">
             <runs />
         </js-module>
+
+        <js-module src="src/electron/pkg/wallet_js.js" name="wasmModule">
+        </js-module>
+
+        <asset src="src/electron/pkg/wallet_js_bg.wasm" target="wallet_js_bg.wasm" />
     </platform>
 
     <!-- ios -->

--- a/bindings/wallet-cordova/src/electron/walletProxy.js
+++ b/bindings/wallet-cordova/src/electron/walletProxy.js
@@ -1,0 +1,77 @@
+const MOCKED_WALLET_PTR = 1000;
+const MOCKED_SETTINGS_PTR = 2000;
+
+const BLOCK0 = 'AFIAAAAAA2kAAAAAAAAAAAAAAAD9i29cnYJNuv/jwQQ120w1IjI6I4/L0XRXVp6J3W381AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKYAAAAOAIgAAAAAXpIscABBAQDCAAEDmAAAAAAAAAAKAAAAAAAAAAIAAAAAAAAAZAEEAAAAtAFBFAQEAACowAIIAAAAAAAAAGQCRAABkAABhAAAAGQFgQEEyAAAWvMQekAABSECAAAAAAAAAGQAAAAAAAAADQAAAAAAAAATAAAAAQAAAAMC4OV86zsoMvB+LvBR53K2KoN/ekhsNeOPUb9Va9OrzY7KAW8AAQUAAAAAAA9CQABMgtgYWEKDWBwJkubjlw3QEFW6kZz/W2cKaBP0HFiOtwEjHjzwoQFYHlgcS/9R5uG88kXHvLYQQV+tQnwti4f6yoRSIVlw9gAaZgoUdwAAAAAAAYagAEyC2BhYQoNYHDZX7ZGtLyWtPrxPrsQEd5+Nr6/AP6GBdDx2qmGhAVgeWBzXyZz6E+gcpV0Cb+A5USRkbjmxiMR1+ydlJZddABq3WXfyAAAAAAAAJxAAK4LYGFghg1gcrf9nixGxJ67wwpboi/tHackFKEcWwj5dYyeHh6AAGmP2eccAAAAAAAAAAQBMgtgYWEKDWBxLrr9gAR0FGwIUOjQXUU/tbyXIwD0iUwJaou1foQFYHlgcS/9R5uG88kXHvLUQTHyp7SAeGxpsbfvpPq3uzgAaMYlycAAAAAAAAABkACuC2BhYIYNYHK3/Z4sRsSeu8MKW6Iv7R2nJBShHFsI+XWMnh4egABpj9nnHAU4AAQUAAAAAAA9CQAArgtgYWCGDWBx4P9MAjQ2PtFMohUgTYMtul9x4AciEPzAO1ppWoAAafYOiHQAAAAAAACcQACuC2BhYIYNYHK3/Z4sRsSeu8MKW6Iv7R2nJBShHFsI+XWMnh4egABpj9nnHAAAAAAAAAAEAK4LYGFghg1gceD/TAI0Nj7RTKIVIE2DLbpfceAHIhD8wDtaaVqAAGn2Doh0AAAAAAAAAZABMgtgYWEKDWBz/2F8gzz8on9CR4LAzKF7K1yVJa8VwNaUEuEoQoQFYHlgcS/9R5uG88kXHvLQQUpmlmMUOq6zdD3KBXAFtpwAaV/kGjwAAAAAAAAPyAEyC2BhYQoNYHIRzKQlzhvJjEhUg/Jw2QEe0NimLN8kUihXv3bShAVgeWBzXyZz6E+gc4X9CIeCu1UwIYloKjGh9l0j0YqayABr4Zri5';
+const WALLET_VALUE = 1000000 + 10000 + 10000 + 1 + 100;
+const YOROI_WALLET = 'neck bulb teach illegal soul cry monitor claw amount boring provide village rival draft stone';
+
+function walletRestore(successCallback, errorCallback, opts) {
+    if (opts && typeof (opts[0]) === 'string') {
+        if (opts[0] === YOROI_WALLET) {
+            successCallback(MOCKED_WALLET_PTR);
+        }
+        else {
+            errorCallback('invalid mnemonics');
+        }
+    }
+    else {
+        errorCallback('no mnemonics');
+    }
+}
+
+function walletRetrieveFunds(successCallback, errorCallback, opts) {
+    if (opts && typeof (opts[1]) === 'string') {
+        if (opts[1] === BLOCK0) {
+            successCallback(MOCKED_SETTINGS_PTR);
+        }
+        else {
+            errorCallback('invalid block');
+        }
+    }
+    else {
+        errorCallback('no block');
+    }
+}
+
+function walletTotalFunds(successCallback, errorCallback, opts) {
+    if (opts && typeof (opts[0]) === 'number') {
+        if (opts[0] === MOCKED_WALLET_PTR) {
+            successCallback(WALLET_VALUE);
+        }
+        else {
+            successCallback(0);
+        }
+    }
+    else {
+        errorCallback('no pointer');
+    }
+
+}
+
+function walletDelete(successCallback, errorCallback, opts) {
+    if (opts && typeof (opts[0]) === 'number') {
+        successCallback();
+    }
+    else {
+        errorCallback();
+    }
+}
+
+function settingsDelete(successCallback, errorCallback, opts) {
+    if (opts && typeof (opts[0]) === 'number') {
+        successCallback();
+    }
+    else {
+        errorCallback();
+    }
+}
+
+bindings = {
+    WALLET_RESTORE: walletRestore,
+    WALLET_RETRIEVE_FUNDS: walletRetrieveFunds,
+    WALLET_TOTAL_FUNDS: walletTotalFunds,
+    WALLET_DELETE: walletDelete,
+    SETTINGS_DELETE: settingsDelete,
+};
+
+require('cordova/exec/proxy').add('WalletPlugin', bindings);


### PR DESCRIPTION
replace the mocks in #47 for an actual implementation. This is rebased from that, so either merge #47 before this, or merge this and close the other.

- Add an electron implementation
- Move the content of `README.md` to a new `TESTING.md`, as the README is what's added to the package and is not that relevant for users.
- Add some placeholders in the README, I'm not sure if it's best to add some examples now, because I the user-facing plugin API may change a bit yet.

## Electron

The electron implementation requires that node integrations are enabled in the app. This is used to load the webassembly by using node's `fs` and some electron functionality to resolve the paths. There may be some ways of work around that (by providing a preload script and requiring the user to load it, maybe), I'm not sure if we need to do it.

## Techical debt

- Add eslint
- The tests don't work (probably the test framework is not compatible with electron. It's tested manually, but we would need some workaround to load the tests here too.
- Fill the README

## Possible improvements

There may be some better way to load the wasm-bindgen module.

## Packaging

Still not in the github workflow, I'll add it later here if this is still open, or create a new one.