### PR TITLE
Return ready-to send fragment raw

### DIFF
--- a/bindings/wallet-core/Cargo.toml
+++ b/bindings/wallet-core/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["lib"]
 thiserror = { version = "1.0.13", default-features = false }
 bip39 = { path = "../../bip39" }
 wallet = { path = "../../wallet" }
+chain-core = { path = "../../chain-deps/chain-core" }
 chain-ser = { path = "../../chain-deps/chain-ser" }
 chain-addr = { path = "../../chain-deps/chain-addr" }
 chain-impl-mockchain = { path = "../../chain-deps/chain-impl-mockchain" }

--- a/bindings/wallet-core/src/c.rs
+++ b/bindings/wallet-core/src/c.rs
@@ -230,8 +230,8 @@ pub unsafe fn wallet_convert_transactions_get(
     };
 
     if let Some(t) = conversion.transactions.get(index) {
-        *transaction_out = t.as_ref().as_ptr();
-        *transaction_size = t.as_ref().len();
+        *transaction_out = t.as_ptr();
+        *transaction_size = t.len();
         Result::success()
     } else {
         Error::wallet_conversion().with(OutOfBound).into()

--- a/bindings/wallet-core/src/conversion.rs
+++ b/bindings/wallet-core/src/conversion.rs
@@ -1,8 +1,8 @@
-use chain_impl_mockchain::transaction::{Input, NoExtra, Transaction};
+use chain_impl_mockchain::{fragment::FragmentRaw, transaction::Input};
 
 pub struct Conversion {
     pub(crate) ignored: Vec<Input>,
-    pub(crate) transactions: Vec<Transaction<NoExtra>>,
+    pub(crate) transactions: Vec<FragmentRaw>,
 }
 
 impl Conversion {
@@ -10,7 +10,7 @@ impl Conversion {
         &self.ignored
     }
 
-    pub fn transactions(&self) -> &[Transaction<NoExtra>] {
+    pub fn transactions(&self) -> &[FragmentRaw] {
         &self.transactions
     }
 }

--- a/bindings/wallet-core/src/conversion.rs
+++ b/bindings/wallet-core/src/conversion.rs
@@ -1,8 +1,8 @@
-use chain_impl_mockchain::{fragment::FragmentRaw, transaction::Input};
+use chain_impl_mockchain::transaction::Input;
 
 pub struct Conversion {
     pub(crate) ignored: Vec<Input>,
-    pub(crate) transactions: Vec<FragmentRaw>,
+    pub(crate) transactions: Vec<Vec<u8>>,
 }
 
 impl Conversion {
@@ -10,7 +10,7 @@ impl Conversion {
         &self.ignored
     }
 
-    pub fn transactions(&self) -> &[FragmentRaw] {
+    pub fn transactions(&self) -> &[Vec<u8>] {
         &self.transactions
     }
 }

--- a/bindings/wallet-core/src/wallet.rs
+++ b/bindings/wallet-core/src/wallet.rs
@@ -1,4 +1,5 @@
 use crate::{Conversion, Error};
+use chain_core::property::Serialize as _;
 use chain_impl_mockchain::{block::Block, value::Value};
 use chain_ser::mempack::{ReadBuf, Readable as _};
 use wallet::Settings;
@@ -124,6 +125,11 @@ impl Wallet {
         self.icarus.dump_in(&mut dump);
 
         let (ignored, transactions) = dump.finalize();
+
+        let transactions = transactions
+            .into_iter()
+            .map(|t| t.serialize_as_vec().unwrap())
+            .collect();
 
         Conversion {
             ignored,

--- a/bindings/wallet-js/src/lib.rs
+++ b/bindings/wallet-js/src/lib.rs
@@ -111,9 +111,6 @@ impl Conversion {
     }
 
     pub fn transactions_get(&self, index: usize) -> Option<Vec<u8>> {
-        self.0
-            .transactions()
-            .get(index)
-            .map(|t| t.as_ref().to_owned())
+        self.0.transactions().get(index).map(|t| t.to_owned())
     }
 }

--- a/wallet/src/transaction/dump.rs
+++ b/wallet/src/transaction/dump.rs
@@ -2,6 +2,7 @@ use crate::{transaction::WitnessBuilder, Settings};
 use chain_addr::Address;
 use chain_impl_mockchain::{
     fee::FeeAlgorithm as _,
+    fragment::{Fragment, FragmentRaw},
     transaction::{Input, NoExtra, Output, Transaction, TxBuilderState},
     value::Value,
 };
@@ -32,7 +33,7 @@ impl Dump {
     /// return the list of ignored inputs and the list of built transactions
     ///
     /// the transactions are ready to send
-    pub fn finalize(mut self) -> (Vec<Input>, Vec<Transaction<NoExtra>>) {
+    pub fn finalize(mut self) -> (Vec<Input>, Vec<FragmentRaw>) {
         self.build_tx_and_clear();
 
         assert!(
@@ -44,7 +45,14 @@ impl Dump {
             "we should not have any more pending inputs to spend"
         );
 
-        (self.ignored, self.outputs)
+        let outputs = self
+            .outputs
+            .into_iter()
+            .map(Fragment::Transaction)
+            .map(|f| Fragment::to_raw(&f))
+            .collect();
+
+        (self.ignored, outputs)
     }
 
     fn inputs_value(&self) -> Value {

--- a/wallet/tests/daedalus.rs
+++ b/wallet/tests/daedalus.rs
@@ -1,7 +1,10 @@
 const BLOCK0: &[u8] = include_bytes!("../../test-vectors/block0");
-use chain_impl_mockchain::block::Block;
-use chain_ser::mempack::{ReadBuf, Readable as _};
-use wallet::*;
+
+mod utils;
+
+use self::utils::State;
+use chain_impl_mockchain::value::Value;
+use wallet::{transaction::Dump, RecoveryBuilder};
 
 /// test to recover a daedalus style address in the test-vectors block0
 ///
@@ -11,20 +14,31 @@ fn daedalus_wallet1() {
         "tired owner misery large dream glad upset welcome shuffle eagle pulp time";
     const WALLET_VALUE: u64 = 100_000 + 1010;
 
-    let mut wallet = RecoveryBuilder::new()
+    let wallet = RecoveryBuilder::new()
         .mnemonics(&bip39::dictionary::ENGLISH, MNEMONICS)
-        .expect("valid mnemonics")
+        .expect("valid mnemonics");
+    let mut daedalus = wallet
         .build_daedalus()
         .expect("recover a Legacy/Daedalus wallet");
+    let account = wallet.build_wallet().expect("recover account");
 
-    let mut block0_bytes = ReadBuf::from(BLOCK0);
-    let block0 = Block::read(&mut block0_bytes).expect("valid block0");
+    let mut state = State::new(BLOCK0);
+    let settings = state.settings().expect("valid initial settings");
+    let address = account.account_id().address(settings.discrimination());
 
-    let _settings = wallet::Settings::new(&block0).expect("valid settings recovering");
-    wallet.check_fragments(block0.contents.iter());
+    daedalus.check_fragments(state.initial_contents());
 
-    let total_value = wallet.value_total();
-    assert_eq!(total_value.as_ref(), &WALLET_VALUE);
+    assert_eq!(daedalus.value_total().as_ref(), &WALLET_VALUE);
+
+    let mut dump = Dump::new(settings, address);
+    daedalus.dump_in(&mut dump);
+    let (ignored, fragments) = dump.finalize();
+
+    assert!(ignored.is_empty());
+
+    state
+        .apply_fragments(fragments.iter())
+        .expect("the dump fragments should be valid");
 }
 
 /// test to recover a daedalus style address in the test-vectors block0
@@ -34,18 +48,30 @@ fn daedalus_wallet2() {
     const MNEMONICS: &str = "edge club wrap where juice nephew whip entry cover bullet cause jeans";
     const WALLET_VALUE: u64 = 1_000_000 + 1 + 100;
 
-    let mut wallet = RecoveryBuilder::new()
+    let wallet = RecoveryBuilder::new()
         .mnemonics(&bip39::dictionary::ENGLISH, MNEMONICS)
-        .expect("valid mnemonics")
+        .expect("valid mnemonics");
+    let mut daedalus = wallet
         .build_daedalus()
         .expect("recover a Legacy/Daedalus wallet");
+    let account = wallet.build_wallet().expect("recover account");
 
-    let mut block0_bytes = ReadBuf::from(BLOCK0);
-    let block0 = Block::read(&mut block0_bytes).expect("valid block0");
+    let mut state = State::new(BLOCK0);
+    let settings = state.settings().expect("valid initial settings");
+    let address = account.account_id().address(settings.discrimination());
 
-    let _settings = wallet::Settings::new(&block0).expect("valid settings recovering");
-    wallet.check_fragments(block0.contents.iter());
+    daedalus.check_fragments(state.initial_contents());
 
-    let total_value = wallet.value_total();
-    assert_eq!(total_value.as_ref(), &WALLET_VALUE);
+    assert_eq!(daedalus.value_total().as_ref(), &WALLET_VALUE);
+
+    let mut dump = Dump::new(settings, address);
+    daedalus.dump_in(&mut dump);
+    let (ignored, fragments) = dump.finalize();
+
+    assert!(ignored.len() == 1, "there is only one ignored input");
+    assert!(ignored[0].value() == Value(1), "the value ignored is `1`");
+
+    state
+        .apply_fragments(fragments.iter())
+        .expect("the dump fragments should be valid");
 }

--- a/wallet/tests/utils/mod.rs
+++ b/wallet/tests/utils/mod.rs
@@ -1,0 +1,53 @@
+use chain_impl_mockchain::{
+    block::Block,
+    fragment::{Fragment, FragmentRaw},
+    ledger::{Error as LedgerError, Ledger},
+};
+use chain_ser::mempack::{ReadBuf, Readable as _};
+use wallet::Settings;
+
+pub struct State {
+    block0: Block,
+    ledger: Ledger,
+}
+
+impl State {
+    pub fn new<B>(block0_bytes: B) -> Self
+    where
+        B: AsRef<[u8]>,
+    {
+        let mut block0_bytes = ReadBuf::from(block0_bytes.as_ref());
+        let block0 = Block::read(&mut block0_bytes).expect("valid block0");
+        let hh = block0.header.id();
+        let ledger = Ledger::new(hh, block0.fragments()).unwrap();
+
+        Self { block0, ledger }
+    }
+
+    pub fn initial_contents(&self) -> impl Iterator<Item = &'_ Fragment> {
+        self.block0.contents.iter()
+    }
+
+    pub fn settings(&self) -> Result<Settings, LedgerError> {
+        Settings::new(&self.block0)
+    }
+
+    pub fn apply_fragments<'a, F>(&'a mut self, fragments: F) -> Result<(), LedgerError>
+    where
+        F: IntoIterator<Item = &'a FragmentRaw>,
+    {
+        let ledger_params = self.ledger.get_ledger_parameters();
+        let block_date = self.ledger.date();
+        let mut new_ledger = self.ledger.clone();
+        for fragment in fragments {
+            let fragment = Fragment::from_raw(fragment).unwrap();
+            new_ledger = self
+                .ledger
+                .apply_fragment(&ledger_params, &fragment, block_date)?;
+        }
+
+        self.ledger = new_ledger;
+
+        Ok(())
+    }
+}

--- a/wallet/tests/yoroi.rs
+++ b/wallet/tests/yoroi.rs
@@ -1,27 +1,41 @@
+mod utils;
+
+use self::utils::State;
+use chain_impl_mockchain::value::Value;
+use wallet::{transaction::Dump, RecoveryBuilder};
+
 const BLOCK0: &[u8] = include_bytes!("../../test-vectors/block0");
 const MNEMONICS: &str =
     "neck bulb teach illegal soul cry monitor claw amount boring provide village rival draft stone";
 const WALLET_VALUE: u64 = 1_000_000 + 10_000 + 10_000 + 1 + 100;
-use chain_impl_mockchain::block::Block;
-use chain_ser::mempack::{ReadBuf, Readable as _};
-use wallet::*;
 
 /// test to recover a daedalus style address in the test-vectors block0
 ///
 #[test]
 fn yoroi1() {
-    let mut wallet = RecoveryBuilder::new()
+    let wallet = RecoveryBuilder::new()
         .mnemonics(&bip39::dictionary::ENGLISH, MNEMONICS)
-        .expect("valid mnemonics")
+        .expect("valid mnemonics");
+    let mut yoroi = wallet
         .build_yoroi()
         .expect("recover an Icarus/Yoroi wallet");
+    let account = wallet.build_wallet().expect("recover account");
 
-    let mut block0_bytes = ReadBuf::from(BLOCK0);
-    let block0 = Block::read(&mut block0_bytes).expect("valid block0");
+    let mut state = State::new(BLOCK0);
+    let settings = state.settings().expect("valid initial settings");
+    let address = account.account_id().address(settings.discrimination());
 
-    let _settings = wallet::Settings::new(&block0).expect("valid settings recovering");
-    wallet.check_fragments(block0.contents.iter());
+    yoroi.check_fragments(state.initial_contents());
+    assert_eq!(yoroi.value_total().as_ref(), &WALLET_VALUE);
 
-    let total_value = wallet.value_total();
-    assert_eq!(total_value.as_ref(), &WALLET_VALUE);
+    let mut dump = Dump::new(settings, address);
+    yoroi.dump_in(&mut dump);
+    let (ignored, fragments) = dump.finalize();
+
+    assert!(ignored.len() == 1, "there is only one ignored input");
+    assert!(ignored[0].value() == Value(1), "the value ignored is `1`");
+
+    state
+        .apply_fragments(fragments.iter())
+        .expect("the dump fragments should be valid");
 }


### PR DESCRIPTION
The transaction were not formatted to be sent to the node already, they needed the extra step to be ready send.

This PR makes sure the transactions are formatted into a ready to send fragment. Also add the tests for the transaction dump into the new address.