### PR TITLE
add conversion get ignored and fix pointer bug

### DIFF
--- a/bindings/wallet-jni/java/WalletTest.java
+++ b/bindings/wallet-jni/java/WalletTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Paths;
 
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class WalletTest {
     @Test
@@ -46,7 +47,13 @@ public class WalletTest {
 
         final byte[] transaction = Conversion.transactionsGet(conversionPtr, 0);
 
-        assertEquals(723, transaction.length);
+        Conversion.ignored(conversionPtr, new Conversion.IgnoredCallback() {
+            @Override
+            public void call(long value, long ignored) {
+                assertEquals(1, value);
+                assertEquals(1, ignored);
+            }
+        });
 
         Conversion.delete(conversionPtr);
         Settings.delete(settingsPtr);

--- a/bindings/wallet-jni/java/com/iohk/jormungandrwallet/Conversion.java
+++ b/bindings/wallet-jni/java/com/iohk/jormungandrwallet/Conversion.java
@@ -10,4 +10,10 @@ public class Conversion {
     public native static int transactionsSize(long conversion);
 
     public native static byte[] transactionsGet(long conversion, int index);
+
+    public native static void ignored(long conversion, IgnoredCallback callback);
+
+    public interface IgnoredCallback {
+        void call(long value, long ignored);
+    }
 }

--- a/bindings/wallet-jni/java/com/iohk/jormungandrwallet/Wallet.java
+++ b/bindings/wallet-jni/java/com/iohk/jormungandrwallet/Wallet.java
@@ -16,4 +16,6 @@ public class Wallet {
     public native static long convert(long wallet, long settings);
 
     public native static byte[] id(long wallet);
+
+    public native static void setState(long wallet, long value, long counter);
 }


### PR DESCRIPTION
- Fix bug where the functions were readings pointer types from jni instead of `jlong`, breaking things in 32bits. I think this could've been avoided with some lint that checks from redundant casts, as the code was casting the pointers to the same type. I'll see if it's possible. I don't know if there is a better way.
- Add conversion get ignored to jni.