### PR TITLE
Add conversion get ignored and set state android electron

### DIFF
--- a/bindings/wallet-cordova/src/android/WalletPlugin.java
+++ b/bindings/wallet-cordova/src/android/WalletPlugin.java
@@ -14,7 +14,7 @@ import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.CordovaArgs;
-import org.json.JSONArray;
+import org.json.JSONObject;
 import org.json.JSONException;
 
 import android.util.Base64;
@@ -67,6 +67,9 @@ public class WalletPlugin extends CordovaPlugin {
             case "WALLET_ID":
                 walletId(args, callbackContext);
                 break;
+            case "WALLET_SET_STATE":
+                walletSetState(args, callbackContext);
+                break;
             case "WALLET_CONVERT":
                 walletConvert(args, callbackContext);
                 break;
@@ -75,6 +78,9 @@ public class WalletPlugin extends CordovaPlugin {
                 break;
             case "CONVERSION_TRANSACTIONS_GET":
                 conversionTransactionsGet(args, callbackContext);
+                break;
+            case "CONVERSION_IGNORED":
+                conversionIgnored(args, callbackContext);
                 break;
             case "WALLET_DELETE":
                 walletDelete(args, callbackContext);
@@ -136,6 +142,19 @@ public class WalletPlugin extends CordovaPlugin {
         }
     }
 
+    private void walletSetState(final CordovaArgs args, final CallbackContext callbackContext) throws JSONException {
+        final Long walletPtr = args.getLong(0);
+        final Long value = args.getLong(1);
+        final Long counter = args.getLong(2);
+
+        try {
+            Wallet.setState(walletPtr, value, counter);
+            callbackContext.success();
+        } catch (final Exception e) {
+            callbackContext.error(e.getMessage());
+        }
+    }
+
     private void walletConvert(final CordovaArgs args, final CallbackContext callbackContext) throws JSONException {
         final Long walletPtr = args.getLong(0);
         final Long settingsPtr = args.getLong(1);
@@ -177,13 +196,33 @@ public class WalletPlugin extends CordovaPlugin {
         }
     }
 
-    private void walletId(final CordovaArgs args, CallbackContext callbackContext) throws JSONException {
+    private void conversionIgnored(final CordovaArgs args, final CallbackContext callbackContext) throws JSONException {
+        final Long conversionPtr = args.getLong(0);
+
+        try {
+            Conversion.ignored(conversionPtr, new Conversion.IgnoredCallback() {
+                @Override
+                public void call(final long value, final long ignored) {
+                    try {
+                        final JSONObject json = new JSONObject().put("value", value).put("ignored", ignored);
+                        callbackContext.success(json);
+                    } catch (final JSONException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+        } catch (final Exception e) {
+            callbackContext.error(e.getMessage());
+        }
+    }
+
+    private void walletId(final CordovaArgs args, final CallbackContext callbackContext) throws JSONException {
         final Long walletPtr = args.getLong(0);
 
         try {
-            byte[] id = Wallet.id(walletPtr);
+            final byte[] id = Wallet.id(walletPtr);
             callbackContext.success(id);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             callbackContext.error(e.getMessage());
         }
     }

--- a/bindings/wallet-cordova/src/electron/walletProxy.js
+++ b/bindings/wallet-cordova/src/electron/walletProxy.js
@@ -51,6 +51,24 @@ async function walletTotalFunds (successCallback, errorCallback, opts) {
     }
 }
 
+async function walletSetState (successCallback, errorCallback, opts) {
+    await loaded;
+    if (opts && typeof (opts[0]) === 'number') {
+        const walletPtr = opts[0];
+        const value = opts[1];
+        const counter = opts[2];
+        const wallet = wasm.Wallet.__wrap(walletPtr);
+        try {
+            wallet.set_state(value, counter);
+            successCallback();
+        } catch (err) {
+            errorCallback(err);
+        }
+    } else {
+        errorCallback('invalid wallet pointer');
+    }
+}
+
 async function walletId (successCallback, errorCallback, opts) {
     await loaded;
     if (opts && typeof (opts[0]) === 'number') {
@@ -118,6 +136,24 @@ async function conversionTransactionsGet (successCallback, errorCallback, opts) 
     }
 }
 
+async function conversionIgnored (successCallback, errorCallback, opts) {
+    await loaded;
+    if (opts && typeof (opts[0]) === 'number') {
+        const conversionPtr = opts[0];
+        const conversion = wasm.Conversion.__wrap(conversionPtr);
+
+        try {
+            const ignored = conversion.num_ignored();
+            const value = conversion.total_value_ignored();
+            successCallback({ ignored, value });
+        } catch (err) {
+            errorCallback(err);
+        }
+    } else {
+        errorCallback('invalid or missing conversion pointer');
+    }
+}
+
 async function walletDelete (successCallback, errorCallback, opts) {
     await loaded;
     if (opts && typeof (opts[0]) === 'number') {
@@ -156,9 +192,11 @@ const bindings = {
     WALLET_RETRIEVE_FUNDS: walletRetrieveFunds,
     WALLET_TOTAL_FUNDS: walletTotalFunds,
     WALLET_ID: walletId,
+    WALLET_SET_STATE: walletSetState,
     WALLET_CONVERT: walletConvert,
     CONVERSION_TRANSACTIONS_SIZE: conversionTransactionsSize,
     CONVERSION_TRANSACTIONS_GET: conversionTransactionsGet,
+    CONVERSION_IGNORED: conversionIgnored,
     WALLET_DELETE: walletDelete,
     SETTINGS_DELETE: settingsDelete,
     CONVERSION_DELETE: conversionDelete

--- a/bindings/wallet-cordova/src/electron/walletProxy.js
+++ b/bindings/wallet-cordova/src/electron/walletProxy.js
@@ -169,7 +169,13 @@ require('cordova/exec/proxy').add('WalletPlugin', bindings);
 // this is in done in order to make it work regardless of where the html file is located
 const appPath = global.require('electron').remote.app.getAppPath();
 const binaryPath = global.require('path').join(appPath, 'wallet_js_bg.wasm');
-// TODO: we could probably do this async
-const bytes = global.require('fs').readFileSync(binaryPath);
 
-const loaded = wasm(bytes);
+const loaded = new Promise(function (resolve, reject) {
+    global.require('fs').readFile(binaryPath, function (err, bytes) {
+        if (err) {
+            reject(err);
+        }
+
+        resolve(bytes);
+    });
+}).then(bytes => wasm(bytes));

--- a/bindings/wallet-cordova/tests/tests.js
+++ b/bindings/wallet-cordova/tests/tests.js
@@ -40,10 +40,12 @@ const restoreWallet = promisify(primitives.walletRestore);
 const retrieveFunds = promisify(primitives.walletRetrieveFunds);
 const totalFunds = promisify(primitives.walletTotalFunds);
 const convertWallet = promisify(primitives.walletConvert);
+const setState = promisify(primitives.walletSetState);
 const deleteWallet = promisify(primitives.walletDelete);
 const deleteSettings = promisify(primitives.settingsDelete);
 const deleteConversion = promisify(primitives.conversionDelete);
 const conversionGetTransactionAt = promisify(primitives.conversionTransactionsGet);
+const conversionGetIgnored = promisify(primitives.conversionTransactionsGetIgnored);
 
 function conversionGetTransactions (conversion) {
     return new Promise(function (resolve, reject) {
@@ -101,6 +103,22 @@ exports.defineAutoTests = function () {
                 });
         });
 
+        // there is nothing we can assert here, I think
+        it('should be able to set state', function (done) {
+            restoreWallet(YOROI_WALLET)
+                .then(function (wallet) {
+                    const value = 1000;
+                    const counter = 2;
+                    setState(wallet, value, counter);
+                })
+                .catch(function (err) {
+                    done.fail('could not set wallet state' + err);
+                })
+                .then(function () {
+                    done();
+                });
+        });
+
         it('should fail with invalid mnemonics', function (done) {
             restoreWallet('invalidmnemonics')
                 .then(
@@ -145,7 +163,11 @@ exports.defineAutoTests = function () {
                 })
                 .then(function (transactions) {
                     expect(transactions.length).toBe(1);
-                    expect(transactions[0].byteLength).toBe(723);
+                    return conversionGetIgnored(conversionPtr);
+                })
+                .then(function (ignored_value) {
+                    expect(ignored_value.value).toBe(1);
+                    expect(ignored_value.ignored).toBe(1);
                     return new Promise(function (resolve) {
                         resolve();
                     });

--- a/bindings/wallet-cordova/www/wallet.js
+++ b/bindings/wallet-cordova/www/wallet.js
@@ -143,7 +143,7 @@ var plugin = {
      * @param {function} successCallback returns an object with ignored, and value properties
      * @param {errorCallback} errorCallback
      */
-    conversionTransactionsGetIgnored: function (ptr, successCallback, errorCallback) {
+    conversionGetIgnored: function (ptr, successCallback, errorCallback) {
         exec(successCallback, errorCallback, NATIVE_CLASS_NAME, CONVERSION_IGNORED_GET_ACTION_TAG, [ptr]);
     },
 

--- a/bindings/wallet-cordova/www/wallet.js
+++ b/bindings/wallet-cordova/www/wallet.js
@@ -7,8 +7,10 @@ const WALLET_RETRIEVE_FUNDS_ACTION_TAG = 'WALLET_RETRIEVE_FUNDS';
 const WALLET_TOTAL_FUNDS_ACTION_TAG = 'WALLET_TOTAL_FUNDS';
 const WALLET_ID_TAG = 'WALLET_ID';
 const WALLET_CONVERT_ACTION_TAG = 'WALLET_CONVERT';
+const WALLET_SET_STATE_ACTION_TAG = 'WALLET_SET_STATE';
 const CONVERSION_TRANSACTIONS_SIZE_ACTION_TAG = 'CONVERSION_TRANSACTIONS_SIZE';
 const CONVERSION_TRANSACTIONS_GET_ACTION_TAG = 'CONVERSION_TRANSACTIONS_GET';
+const CONVERSION_IGNORED_GET_ACTION_TAG = 'CONVERSION_IGNORED';
 const WALLET_DELETE_ACTION_TAG = 'WALLET_DELETE';
 const SETTINGS_DELETE_ACTION_TAG = 'SETTINGS_DELETE';
 const CONVERSION_DELETE_ACTION_TAG = 'CONVERSION_DELETE';
@@ -82,6 +84,32 @@ var plugin = {
     },
 
     /**
+     *
+     * update the wallet account state
+     *
+     * this is the value retrieved from any jormungandr endpoint that allows to query
+     * for the account state. It gives the value associated to the account as well as
+     * the counter.
+     *
+     * It is important to be sure to have an updated wallet state before doing any
+     * transactions otherwise future transactions may fail to be accepted by any
+     * nodes of the blockchain because of invalid signature state.
+     *
+     * # Errors
+     *
+     * this function may fail if the wallet pointer is null;
+     * @param {number} ptr a pointer to a Wallet object obtained with WalletRestore
+     * @param {number} value
+     * @param {number} counter
+     * @param {function} successCallback
+     * @param {function} errorCallback
+     *
+     */
+    walletSetState: function (ptr, value, counter, successCallback, errorCallback) {
+        exec(successCallback, errorCallback, NATIVE_CLASS_NAME, WALLET_SET_STATE_ACTION_TAG, [ptr, value, counter]);
+    },
+
+    /**
      * @param {number} walletPtr a pointer to a wallet obtained with walletRestore
      * @param {number} settingsPtr a pointer to a settings object obtained with walletRetrieveFunds
      * @param {pointerCallback} successCallback returns a Conversion object
@@ -108,6 +136,15 @@ var plugin = {
      */
     conversionTransactionsGet: function (ptr, index, successCallback, errorCallback) {
         exec(successCallback, errorCallback, NATIVE_CLASS_NAME, CONVERSION_TRANSACTIONS_GET_ACTION_TAG, [ptr, index]);
+    },
+
+    /**
+     * @param {number} ptr a pointer to a Conversion object obtained with walletConvert
+     * @param {function} successCallback returns an object with ignored, and value properties
+     * @param {errorCallback} errorCallback
+     */
+    conversionTransactionsGetIgnored: function (ptr, successCallback, errorCallback) {
+        exec(successCallback, errorCallback, NATIVE_CLASS_NAME, CONVERSION_IGNORED_GET_ACTION_TAG, [ptr]);
     },
 
     /**

--- a/bindings/wallet-jni/java/WalletTest.java
+++ b/bindings/wallet-jni/java/WalletTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Paths;
 
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class WalletTest {
     @Test
@@ -46,7 +47,13 @@ public class WalletTest {
 
         final byte[] transaction = Conversion.transactionsGet(conversionPtr, 0);
 
-        assertEquals(723, transaction.length);
+        Conversion.ignored(conversionPtr, new Conversion.IgnoredCallback() {
+            @Override
+            public void call(long value, long ignored) {
+                assertEquals(1, value);
+                assertEquals(1, ignored);
+            }
+        });
 
         Conversion.delete(conversionPtr);
         Settings.delete(settingsPtr);

--- a/bindings/wallet-jni/java/com/iohk/jormungandrwallet/Conversion.java
+++ b/bindings/wallet-jni/java/com/iohk/jormungandrwallet/Conversion.java
@@ -10,4 +10,10 @@ public class Conversion {
     public native static int transactionsSize(long conversion);
 
     public native static byte[] transactionsGet(long conversion, int index);
+
+    public native static void ignored(long conversion, IgnoredCallback callback);
+
+    public interface IgnoredCallback {
+        void call(long value, long ignored);
+    }
 }

--- a/bindings/wallet-jni/java/com/iohk/jormungandrwallet/Wallet.java
+++ b/bindings/wallet-jni/java/com/iohk/jormungandrwallet/Wallet.java
@@ -16,4 +16,6 @@ public class Wallet {
     public native static long convert(long wallet, long settings);
 
     public native static byte[] id(long wallet);
+
+    public native static void setState(long wallet, long value, long counter);
 }


### PR DESCRIPTION
- Add function to set wallet state to cordova plugin, for electron and android 
- Add function to get conversion ignored to cordova plugin, for electron and android

This is branched from #60 because without the JNI bindings this won't  work. So that should be merged first (or just close and merge this). I could also rebase this to not include those commits, if the reviewer prefers that (but still shouldn't be merged without the other).