### PR TITLE
Wallet retrieve funds only once

### DIFF
--- a/bindings/wallet-core/src/wallet.rs
+++ b/bindings/wallet-core/src/wallet.rs
@@ -99,8 +99,13 @@ impl Wallet {
 
         let settings = wallet::Settings::new(&block0).unwrap();
         for fragment in block0.contents.iter() {
-            self.daedalus.check_fragment(fragment);
-            self.icarus.check_fragment(fragment);
+            self.daedalus
+                .check_fragment(fragment)
+                .map_err(|e| Error::wallet_recovering().with(e))?;
+
+            self.icarus
+                .check_fragment(fragment)
+                .map_err(|e| Error::wallet_recovering().with(e))?;
         }
         Ok(settings)
     }

--- a/wallet/src/recovering/daedalus.rs
+++ b/wallet/src/recovering/daedalus.rs
@@ -74,12 +74,12 @@ impl RecoveringDaedalus {
         address: &OldAddress,
     ) -> Result<(), RecoveryError> {
         if let Some(derivation_path) = self.address_recovering.check_address(address) {
-            self.value_total = self.value_total.saturating_add(pointer.value);
             let key = self.wallet.key(&derivation_path);
             match self.utxos.entry(pointer) {
                 Entry::Occupied(_entry) => return Err(RecoveryError::DuplicatedUtxo),
                 Entry::Vacant(entry) => entry.insert(key),
             };
+            self.value_total = self.value_total.saturating_add(pointer.value);
         }
         Ok(())
     }

--- a/wallet/src/recovering/icarus.rs
+++ b/wallet/src/recovering/icarus.rs
@@ -184,12 +184,11 @@ impl RecoveringIcarus {
         address: &OldAddress,
     ) -> Result<(), RecoveryError> {
         if let Some(key) = self.check_address(address) {
-            self.value_total = self.value_total.saturating_add(pointer.value);
-
             match self.utxos.entry(pointer) {
                 Entry::Occupied(_entry) => return Err(RecoveryError::DuplicatedUtxo),
                 Entry::Vacant(entry) => entry.insert(key),
             };
+            self.value_total = self.value_total.saturating_add(pointer.value);
         }
         Ok(())
     }

--- a/wallet/src/recovering/icarus.rs
+++ b/wallet/src/recovering/icarus.rs
@@ -126,7 +126,7 @@ impl RecoveringIcarus {
         }
     }
 
-    fn check_address(&mut self, address: &OldAddress) -> Option<Address<XPrv>> {
+    pub(super) fn check_address(&mut self, address: &OldAddress) -> Option<Address<XPrv>> {
         let mut accounts = self.accounts.iter_mut();
         let mut result = None;
 

--- a/wallet/src/recovering/mod.rs
+++ b/wallet/src/recovering/mod.rs
@@ -24,6 +24,8 @@ pub enum RecoveryError {
 
     #[error("Missing entropy, either missing the mnemonics or need to generate a new wallet")]
     MissingEntropy,
+    #[error("Tried to recover same utxo more than once, either the function was called twice or the block is malformed")]
+    DuplicatedUtxo,
 }
 
 #[derive(Default)]

--- a/wallet/src/recovering/mod.rs
+++ b/wallet/src/recovering/mod.rs
@@ -249,6 +249,12 @@ mod tests {
         "sxtitePxjp5Y7GQre2hj7LPAnZp7F49KxE6Cg1huwTzjWbfW2Jd7hSgSqsbMzESs8aQC44ng1LJdnLKqiou4m4gGy8",
     ];
 
+    const MNEMONICS3: &str = "neck bulb teach illegal soul cry monitor claw amount boring provide village rival draft stone";
+    const ADDRESSES3: &[&str] = &[
+        "Ae2tdPwUPEZ8og5u4WF5rmSyme5Gvp8RYiLM2u7Vm8CyDQzLN3VYTN895Wk",
+        "Ae2tdPwUPEZEAjEsQsCtBMkLKANxQUEvzLkumPWWYugLeXcgkeMCDH1gnuL",
+    ];
+
     /// not sure yet, but it appears this test is not valid
     ///
     /// the mnemonics may not be correct?
@@ -305,11 +311,10 @@ mod tests {
     }
 
     #[test]
-    fn recover_utxo_twice_fails() {
+    fn recover_daedalus_utxo_twice_fails() {
         use chain_impl_mockchain::{
             fragment::Fragment,
             legacy::{OldAddress, UtxoDeclaration},
-            transaction::UtxoPointer,
             value::Value,
         };
 
@@ -319,14 +324,37 @@ mod tests {
             .build_daedalus()
             .unwrap();
 
-        for address in ADDRESSES1 {
-            use std::str::FromStr as _;
-            let addr = cardano_legacy_address::Addr::from_str(address).unwrap();
-            assert!(wallet.check_address(&addr));
-        }
-
         let address: OldAddress = ADDRESSES1[0].parse().unwrap();
         assert!(wallet.check_address(&address));
+
+        let fragment_value = Value(10);
+        let fragment = Fragment::OldUtxoDeclaration(UtxoDeclaration {
+            addrs: vec![(address, fragment_value)],
+        });
+
+        assert_eq!(wallet.value_total(), Value(0));
+        assert!(wallet.check_fragment(&fragment).is_ok());
+        assert_eq!(wallet.value_total(), fragment_value);
+        assert!(wallet.check_fragment(&fragment).is_err());
+        assert_eq!(wallet.value_total(), fragment_value);
+    }
+
+    #[test]
+    fn recover_yoroi_utxo_twice_fails() {
+        use chain_impl_mockchain::{
+            fragment::Fragment,
+            legacy::{OldAddress, UtxoDeclaration},
+            value::Value,
+        };
+
+        let mut wallet = RecoveryBuilder::new()
+            .mnemonics(&bip39::dictionary::ENGLISH, MNEMONICS3)
+            .unwrap()
+            .build_yoroi()
+            .unwrap();
+
+        let address: OldAddress = ADDRESSES3[0].parse().unwrap();
+        assert!(wallet.check_address(&address).is_some());
 
         let fragment_value = Value(10);
         let fragment = Fragment::OldUtxoDeclaration(UtxoDeclaration {

--- a/wallet/tests/daedalus.rs
+++ b/wallet/tests/daedalus.rs
@@ -26,7 +26,9 @@ fn daedalus_wallet1() {
     let settings = state.settings().expect("valid initial settings");
     let address = account.account_id().address(settings.discrimination());
 
-    daedalus.check_fragments(state.initial_contents());
+    daedalus
+        .check_fragments(state.initial_contents())
+        .expect("failed to check fragments");
 
     assert_eq!(daedalus.value_total().as_ref(), &WALLET_VALUE);
 
@@ -60,7 +62,9 @@ fn daedalus_wallet2() {
     let settings = state.settings().expect("valid initial settings");
     let address = account.account_id().address(settings.discrimination());
 
-    daedalus.check_fragments(state.initial_contents());
+    daedalus
+        .check_fragments(state.initial_contents())
+        .expect("failed to check fragments");
 
     assert_eq!(daedalus.value_total().as_ref(), &WALLET_VALUE);
 

--- a/wallet/tests/yoroi.rs
+++ b/wallet/tests/yoroi.rs
@@ -25,7 +25,9 @@ fn yoroi1() {
     let settings = state.settings().expect("valid initial settings");
     let address = account.account_id().address(settings.discrimination());
 
-    yoroi.check_fragments(state.initial_contents());
+    yoroi
+        .check_fragments(state.initial_contents())
+        .expect("couldn't check fragments");
     assert_eq!(yoroi.value_total().as_ref(), &WALLET_VALUE);
 
     let mut dump = Dump::new(settings, address);


### PR DESCRIPTION
relates to #57 

replace the `Vec` in `RecoveringDaedalus` and `RecoveringIcarus` by `HashMap` with `UtxoPointer` as key, and return an error if we try to add an utxo twice.

Not sure if this is what we want, but it's just a few lines so I implemented anyway.

Btw, it seems like there is some code duplication between the two recovering structs, although it's rather minor and it's probably not worth to deal with.