### PR TITLE
change cordova plugin test to match api get ignored function name

### DIFF
--- a/bindings/wallet-cordova/tests/tests.js
+++ b/bindings/wallet-cordova/tests/tests.js
@@ -45,7 +45,7 @@ const deleteWallet = promisify(primitives.walletDelete);
 const deleteSettings = promisify(primitives.settingsDelete);
 const deleteConversion = promisify(primitives.conversionDelete);
 const conversionGetTransactionAt = promisify(primitives.conversionTransactionsGet);
-const conversionGetIgnored = promisify(primitives.conversionTransactionsGetIgnored);
+const conversionGetIgnored = promisify(primitives.conversionGetIgnored);
 
 function conversionGetTransactions (conversion) {
     return new Promise(function (resolve, reject) {


### PR DESCRIPTION
Somehow at some point I changed the function name without including the change in the test file. @eugene-babichenko in case you run into this.