### PR TITLE
Add cordova argscheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ This includes bindings for Android Kotlin already packaged in a AAR package.
 
 ### Cordova plugin
 
-_under construction_
+| Platform | supported |
+| -------- | :-------: |
+| android  |     ✓     |
+| ios      |     ✓     |
+| electron |     ✓     |
 
 ### iOS
 

--- a/bindings/wallet-cordova/src/electron/walletProxy.js
+++ b/bindings/wallet-cordova/src/electron/walletProxy.js
@@ -1,3 +1,4 @@
+/* global BigInt */
 const wasm = require('wallet-cordova-plugin.wasmModule');
 
 async function walletRestore (successCallback, errorCallback, opts) {
@@ -7,7 +8,7 @@ async function walletRestore (successCallback, errorCallback, opts) {
         const password = '';
         try {
             const wallet = wasm.Wallet.recover(mnemonics, password);
-            successCallback(wallet.ptr);
+            successCallback(wallet.ptr.toString());
         } catch (err) {
             errorCallback(`couldn't recover wallet ${err}`);
         }
@@ -18,7 +19,7 @@ async function walletRestore (successCallback, errorCallback, opts) {
 
 async function walletRetrieveFunds (successCallback, errorCallback, opts) {
     await loaded;
-    if (opts && typeof (opts[0]) === 'number' && opts[1] instanceof ArrayBuffer) {
+    if (opts && typeof (opts[0]) === 'string' && opts[1] instanceof ArrayBuffer) {
         const walletPtr = opts[0];
         const block = opts[1];
 
@@ -26,7 +27,7 @@ async function walletRetrieveFunds (successCallback, errorCallback, opts) {
 
         try {
             const settings = wallet.retrieve_funds(new Uint8Array(block));
-            successCallback(settings.ptr);
+            successCallback(settings.ptr.toString());
         } catch (err) {
             errorCallback(`couldn't retrieve funds ${err}`);
         }
@@ -37,12 +38,12 @@ async function walletRetrieveFunds (successCallback, errorCallback, opts) {
 
 async function walletTotalFunds (successCallback, errorCallback, opts) {
     await loaded;
-    if (opts && typeof (opts[0]) === 'number') {
+    if (opts && typeof (opts[0]) === 'string') {
         const walletPtr = opts[0];
         const wallet = wasm.Wallet.__wrap(walletPtr);
 
         try {
-            successCallback(wallet.total_value());
+            successCallback(wallet.total_value().toString());
         } catch (err) {
             errorCallback(`couldn't get funds ${err}`);
         }
@@ -53,13 +54,13 @@ async function walletTotalFunds (successCallback, errorCallback, opts) {
 
 async function walletSetState (successCallback, errorCallback, opts) {
     await loaded;
-    if (opts && typeof (opts[0]) === 'number') {
+    if (opts && typeof (opts[0]) === 'string') {
         const walletPtr = opts[0];
         const value = opts[1];
         const counter = opts[2];
         const wallet = wasm.Wallet.__wrap(walletPtr);
         try {
-            wallet.set_state(value, counter);
+            wallet.set_state(BigInt(value), counter);
             successCallback();
         } catch (err) {
             errorCallback(err);
@@ -71,7 +72,7 @@ async function walletSetState (successCallback, errorCallback, opts) {
 
 async function walletId (successCallback, errorCallback, opts) {
     await loaded;
-    if (opts && typeof (opts[0]) === 'number') {
+    if (opts && typeof (opts[0]) === 'string') {
         const walletPtr = opts[0];
         const wallet = wasm.Wallet.__wrap(walletPtr);
 
@@ -87,14 +88,14 @@ async function walletId (successCallback, errorCallback, opts) {
 
 async function walletConvert (successCallback, errorCallback, opts) {
     await loaded;
-    if (opts && typeof (opts[0]) === 'number' && typeof (opts[1]) === 'number') {
+    if (opts && typeof (opts[0]) === 'string' && typeof (opts[1]) === 'string') {
         const walletPtr = opts[0];
         const settingsPtr = opts[1];
         const wallet = wasm.Wallet.__wrap(walletPtr);
         const settings = wasm.Settings.__wrap(settingsPtr);
 
         try {
-            successCallback(wallet.convert(settings).ptr);
+            successCallback(wallet.convert(settings).ptr.toString());
         } catch (err) {
             errorCallback(`couldn't get funds ${err}`);
         }
@@ -105,7 +106,7 @@ async function walletConvert (successCallback, errorCallback, opts) {
 
 async function conversionTransactionsSize (successCallback, errorCallback, opts) {
     await loaded;
-    if (opts && typeof (opts[0]) === 'number') {
+    if (opts && typeof (opts[0]) === 'string') {
         const conversionPtr = opts[0];
         const conversion = wasm.Conversion.__wrap(conversionPtr);
 
@@ -121,7 +122,7 @@ async function conversionTransactionsSize (successCallback, errorCallback, opts)
 
 async function conversionTransactionsGet (successCallback, errorCallback, opts) {
     await loaded;
-    if (opts && typeof (opts[0]) === 'number' && typeof (opts[1]) === 'number') {
+    if (opts && typeof (opts[0]) === 'string' && typeof (opts[1]) === 'number') {
         const conversionPtr = opts[0];
         const index = opts[1];
         const conversion = wasm.Conversion.__wrap(conversionPtr);
@@ -138,7 +139,7 @@ async function conversionTransactionsGet (successCallback, errorCallback, opts) 
 
 async function conversionIgnored (successCallback, errorCallback, opts) {
     await loaded;
-    if (opts && typeof (opts[0]) === 'number') {
+    if (opts && typeof (opts[0]) === 'string') {
         const conversionPtr = opts[0];
         const conversion = wasm.Conversion.__wrap(conversionPtr);
 
@@ -156,7 +157,7 @@ async function conversionIgnored (successCallback, errorCallback, opts) {
 
 async function walletDelete (successCallback, errorCallback, opts) {
     await loaded;
-    if (opts && typeof (opts[0]) === 'number') {
+    if (opts && typeof (opts[0]) === 'string') {
         const walletPtr = opts[0];
         wasm.Wallet.__wrap(walletPtr).free();
         successCallback();
@@ -167,7 +168,7 @@ async function walletDelete (successCallback, errorCallback, opts) {
 
 async function settingsDelete (successCallback, errorCallback, opts) {
     await loaded;
-    if (opts && typeof (opts[0]) === 'number') {
+    if (opts && typeof (opts[0]) === 'string') {
         const settingsPtr = opts[0];
         wasm.Settings.__wrap(settingsPtr).free();
         successCallback();
@@ -178,7 +179,7 @@ async function settingsDelete (successCallback, errorCallback, opts) {
 
 async function conversionDelete (successCallback, errorCallback, opts) {
     await loaded;
-    if (opts && typeof (opts[0]) === 'number') {
+    if (opts && typeof (opts[0]) === 'string') {
         const conversionPtr = opts[0];
         wasm.Conversion.__wrap(conversionPtr).free();
         successCallback();

--- a/bindings/wallet-cordova/www/wallet.js
+++ b/bindings/wallet-cordova/www/wallet.js
@@ -1,4 +1,5 @@
 var exec = require('cordova/exec');
+var argscheck = require('cordova/argscheck');
 
 const NATIVE_CLASS_NAME = 'WalletPlugin';
 
@@ -28,7 +29,7 @@ const CONVERSION_DELETE_ACTION_TAG = 'CONVERSION_DELETE';
 var plugin = {
     /**
      * @callback pointerCallback
-     * @param {number} ptr - callback that returns a pointer to a native object
+     * @param {string} ptr - callback that returns a pointer to a native object
      */
 
     /**
@@ -42,24 +43,33 @@ var plugin = {
      * @param {errorCallback} errorCallback this function can fail if the mnemonics are invalid
      */
     walletRestore: function (mnemonics, successCallback, errorCallback) {
+        argscheck.checkArgs('sff', 'walletRestore', arguments);
         exec(successCallback, errorCallback, NATIVE_CLASS_NAME, WALLET_RESTORE_ACTION_TAG, [mnemonics]);
     },
 
     /**
+     * @param {string} ptr a pointer to a wallet obtained with walletRestore
      * @param {Uint8Array} block0 a byte array representing the block
      * @param {function} successCallback returns a pointer to the blockchain settings extracted from the block
      * @param {errorCallback} errorCallback this can fail if the block or the pointer are invalid
      */
     walletRetrieveFunds: function (ptr, block0, successCallback, errorCallback) {
-        exec(successCallback, errorCallback, NATIVE_CLASS_NAME, WALLET_RETRIEVE_FUNDS_ACTION_TAG, [ptr, block0.buffer]);
+        argscheck.checkArgs('s*ff', 'walletRetrieveFunds', arguments);
+        // cordova checkArgs doesn't support Uint8Array, so we use the * to let it pass and then check it ourselves
+        if (require('cordova/utils').typeName(block0) === 'Uint8Array') {
+            exec(successCallback, errorCallback, NATIVE_CLASS_NAME, WALLET_RETRIEVE_FUNDS_ACTION_TAG, [ptr, block0.buffer]);
+        } else {
+            throw TypeError('expected block0 to be a Uint8Array in walletRetrieveFunds');
+        }
     },
 
     /**
-     * @param {number} ptr a pointer to a wallet obtained with walletRestore
+     * @param {string} ptr a pointer to a wallet obtained with walletRestore
      * @param {function} successCallback returns a number
      * @param {errorCallback} errorCallback description (TODO)
      */
     walletTotalFunds: function (ptr, successCallback, errorCallback) {
+        argscheck.checkArgs('sff', 'walletTotalFunds', arguments);
         exec(successCallback, errorCallback, NATIVE_CLASS_NAME, WALLET_TOTAL_FUNDS_ACTION_TAG, [ptr]);
     },
 
@@ -75,11 +85,12 @@ var plugin = {
      * the function checks if the pointers are null. Mind not to put random values
      * in or you may see unexpected behaviors
      *
-     * @param {number} ptr a pointer to a Wallet object obtained with WalletRestore
+     * @param {string} ptr a pointer to a Wallet object obtained with WalletRestore
      * @param {function} successCallback the return value is an ArrayBuffer, which has the binary representation of the account id.
      * @param {function} errorCallback this function may fail if the wallet pointer is null
      */
     walletId: function (ptr, successCallback, errorCallback) {
+        argscheck.checkArgs('sff', 'walletId', arguments);
         exec(successCallback, errorCallback, NATIVE_CLASS_NAME, WALLET_ID_TAG, [ptr]);
     },
 
@@ -98,7 +109,7 @@ var plugin = {
      * # Errors
      *
      * this function may fail if the wallet pointer is null;
-     * @param {number} ptr a pointer to a Wallet object obtained with WalletRestore
+     * @param {string} ptr a pointer to a Wallet object obtained with WalletRestore
      * @param {number} value
      * @param {number} counter
      * @param {function} successCallback
@@ -106,71 +117,79 @@ var plugin = {
      *
      */
     walletSetState: function (ptr, value, counter, successCallback, errorCallback) {
+        argscheck.checkArgs('snnff', 'walletSetState', arguments);
         exec(successCallback, errorCallback, NATIVE_CLASS_NAME, WALLET_SET_STATE_ACTION_TAG, [ptr, value, counter]);
     },
 
     /**
-     * @param {number} walletPtr a pointer to a wallet obtained with walletRestore
-     * @param {number} settingsPtr a pointer to a settings object obtained with walletRetrieveFunds
+     * @param {string} walletPtr a pointer to a wallet obtained with walletRestore
+     * @param {string} settingsPtr a pointer to a settings object obtained with walletRetrieveFunds
      * @param {pointerCallback} successCallback returns a Conversion object
      * @param {errorCallback} errorCallback description (TODO)
      */
     walletConvert: function (walletPtr, settingsPtr, successCallback, errorCallback) {
+        argscheck.checkArgs('ssff', 'walletConvert', arguments);
         exec(successCallback, errorCallback, NATIVE_CLASS_NAME, WALLET_CONVERT_ACTION_TAG, [walletPtr, settingsPtr]);
     },
 
     /**
-     * @param {number} ptr a pointer to a Conversion object obtained with walletConvert
+     * @param {string} ptr a pointer to a Conversion object obtained with walletConvert
      * @param {function} successCallback returns a number representing the number of transactions produced by the conversion
      * @param {errorCallback} errorCallback description (TODO)
      */
     conversionTransactionsSize: function (ptr, successCallback, errorCallback) {
+        argscheck.checkArgs('sff', 'conversionTransactionsSize', arguments);
         exec(successCallback, errorCallback, NATIVE_CLASS_NAME, CONVERSION_TRANSACTIONS_SIZE_ACTION_TAG, [ptr]);
     },
 
     /**
-     * @param {number} ptr a pointer to a Conversion object obtained with walletConvert
+     * @param {string} ptr a pointer to a Conversion object obtained with walletConvert
      * @param {number} index an index (starting from 0). Use conversionTransactionsSize to get the upper bound
      * @param {function} successCallback callback that receives a transaction in binary form
      * @param {errorCallback} errorCallback this function can fail if the index is out of range
      */
     conversionTransactionsGet: function (ptr, index, successCallback, errorCallback) {
+        argscheck.checkArgs('snff', 'conversionTransactiosGet', arguments);
         exec(successCallback, errorCallback, NATIVE_CLASS_NAME, CONVERSION_TRANSACTIONS_GET_ACTION_TAG, [ptr, index]);
     },
 
     /**
-     * @param {number} ptr a pointer to a Conversion object obtained with walletConvert
+     * @param {string} ptr a pointer to a Conversion object obtained with walletConvert
      * @param {function} successCallback returns an object with ignored, and value properties
      * @param {errorCallback} errorCallback
      */
     conversionGetIgnored: function (ptr, successCallback, errorCallback) {
+        argscheck.checkArgs('sff', 'conversionGetIgnored', arguments);
         exec(successCallback, errorCallback, NATIVE_CLASS_NAME, CONVERSION_IGNORED_GET_ACTION_TAG, [ptr]);
     },
 
     /**
-     * @param {number} walletPtr a pointer to a Wallet obtained with walletRestore
+     * @param {string} ptr a pointer to a Wallet obtained with walletRestore
      * @param {function} successCallback  indicates success. Does not return anything.
      * @param {errorCallback} errorCallback
      */
     walletDelete: function (ptr, successCallback, errorCallback) {
+        argscheck.checkArgs('sff', 'walletDelete', arguments);
         exec(successCallback, errorCallback, NATIVE_CLASS_NAME, WALLET_DELETE_ACTION_TAG, [ptr]);
     },
 
     /**
-     * @param {number} ptr a pointer to a Settings object obtained with walletRetrieveFunds
+     * @param {string} ptr a pointer to a Settings object obtained with walletRetrieveFunds
      * @param {function} successCallback  indicates success. Does not return anything.
      * @param {errorCallback} errorCallback
      */
     settingsDelete: function (ptr, successCallback, errorCallback) {
+        argscheck.checkArgs('sff', 'settingsDelete', arguments);
         exec(successCallback, errorCallback, NATIVE_CLASS_NAME, SETTINGS_DELETE_ACTION_TAG, [ptr]);
     },
 
     /**
-     * @param {number} ptr a pointer to a Conversion object obtained with walletConvert
+     * @param {string} ptr a pointer to a Conversion object obtained with walletConvert
      * @param {function} successCallback  indicates success. Does not return anything.
      * @param {errorCallback} errorCallback
      */
     conversionDelete: function (ptr, successCallback, errorCallback) {
+        argscheck.checkArgs('sff', 'conversionDelete', arguments);
         exec(successCallback, errorCallback, NATIVE_CLASS_NAME, CONVERSION_DELETE_ACTION_TAG, [ptr]);
     }
 };


### PR DESCRIPTION
- Check argument types in js (top module) for every function, so we can rely on that for every platform.
- Normalize the electron plugin so it uses the same types as the native ones.
- Fix the documentation, because pointers are actually string and not numbers. (it doesn't make any difference, because they are never constructed by the api user, they are just a handle type).