### PR TITLE
Add vote cast to jni

### DIFF
--- a/bindings/wallet-cordova/plugin.xml
+++ b/bindings/wallet-cordova/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="wallet-cordova-plugin"
-    version="2.0.0">
+    version="3.0.1">
     <name>Wallet Cordova Plugin</name>
     <description>Wallet Cordova Plugin</description>
     <license>MIT OR Apache-2.0 </license>
@@ -27,6 +27,7 @@
         <source-file src="src/android/jormungandrwallet/Settings.java" target-dir="src/com/iohk/jormungandrwallet" />
         <source-file src="src/android/jormungandrwallet/Wallet.java" target-dir="src/com/iohk/jormungandrwallet" />
         <source-file src="src/android/jormungandrwallet/Conversion.java" target-dir="src/com/iohk/jormungandrwallet" />
+        <source-file src="src/android/jormungandrwallet/Proposal.java" target-dir="src/com/iohk/jormungandrwallet" />
 
         <source-file src="src/android/libs/x86/libwallet_jni.so" target-dir="libs/x86" />
         <source-file src="src/android/libs/x86_64/libwallet_jni.so" target-dir="libs/x86_64" />

--- a/bindings/wallet-cordova/tests/plugin.xml
+++ b/bindings/wallet-cordova/tests/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="wallet-cordova-plugin-tests"
-    version="2.0.0">
+    version="3.0.1">
     <name>Wallet cordova plugin tests</name>
     <license>Apache 2.0 OR MIT</license>
 

--- a/bindings/wallet-cordova/www/wallet.js
+++ b/bindings/wallet-cordova/www/wallet.js
@@ -19,6 +19,8 @@ const SETTINGS_DELETE_ACTION_TAG = 'SETTINGS_DELETE';
 const CONVERSION_DELETE_ACTION_TAG = 'CONVERSION_DELETE';
 const PROPOSAL_DELETE_ACTION_TAG = 'PROPOSAL_DELETE';
 
+const VOTE_PLAN_ID_LENGTH = 32;
+
 /**
  * THOUGHTS/TODO
  * add a more idiomatic abstraction on top of these primitive functions and expose that, something more similar to what wasm-bindgen does
@@ -134,16 +136,17 @@ var plugin = {
 
     /**
      *
+     * Get a signed transaction with a vote of `choice` to the given proposal, ready to be sent to the network.
      *
      * # Errors
      *
      * this function may fail if if any of the pointers are is null;
-     * @param {string} walletPtr a pointer to a Wallet object obtained with WalletRestore
-     * @param {string} settingsPtr
-     * @param {string} proposalPtr
-     * @param {number} choice
-     * @param {function} successCallback
-     * @param {function} errorCallback
+     * @param {string} walletPtr a pointer to a Wallet object obtained with walletRestore
+     * @param {string} settingsPtr a pointer to a Settings object obtained with walletRetrieveFunds
+     * @param {string} proposalPtr a pointer to a Proposal object obtained with proposalNew
+     * @param {number} choice a number between 0 and Proposal's numChoices - 1
+     * @param {function} successCallback on success the callback returns a byte array representing a transaction
+     * @param {function} errorCallback can fail if the choice doesn't validate with the given proposal
      *
      */
     walletVote: function (walletPtr, settingsPtr, proposalPtr, choice, successCallback, errorCallback) {
@@ -194,16 +197,21 @@ var plugin = {
     },
 
     /**
-     * @param {string} votePlanId
+     * Get a proposal object, used to validate the vote on `walletVote`
+     *
+     * @param {Uint8Array} votePlanId a byte array of 32 elements that identifies the voteplan
      * @param {PayloadType} payloadType
-     * @param {number} index
-     * @param {number} numChoices
+     * @param {number} index the index of the proposal in the voteplan
+     * @param {number} numChoices the number of choices of the proposal, used to validate the choice
      * @param {function} successCallback returns an object with ignored, and value properties
      * @param {errorCallback} errorCallback
      */
     proposalNew: function (votePlanId, payloadType, index, numChoices, successCallback, errorCallback) {
         argscheck.checkArgs('*nnnff', 'proposalNew', arguments);
-        if (require('cordova/utils').typeName(votePlanId) === 'Uint8Array') {
+
+        var isArray = require('cordova/utils').typeName(votePlanId) === 'Uint8Array';
+
+        if (isArray && votePlanId.length === VOTE_PLAN_ID_LENGTH) {
             exec(successCallback, errorCallback, NATIVE_CLASS_NAME, PROPOSAL_NEW_ACTION_TAG, [votePlanId, payloadType, index, numChoices]);
         } else {
             throw TypeError('expected votePlanId to be a Uint8Array in proposalNew');

--- a/bindings/wallet-cordova/www/wallet.js
+++ b/bindings/wallet-cordova/www/wallet.js
@@ -9,12 +9,15 @@ const WALLET_TOTAL_FUNDS_ACTION_TAG = 'WALLET_TOTAL_FUNDS';
 const WALLET_ID_TAG = 'WALLET_ID';
 const WALLET_CONVERT_ACTION_TAG = 'WALLET_CONVERT';
 const WALLET_SET_STATE_ACTION_TAG = 'WALLET_SET_STATE';
+const WALLET_VOTE_ACTION_TAG = 'WALLET_VOTE';
 const CONVERSION_TRANSACTIONS_SIZE_ACTION_TAG = 'CONVERSION_TRANSACTIONS_SIZE';
 const CONVERSION_TRANSACTIONS_GET_ACTION_TAG = 'CONVERSION_TRANSACTIONS_GET';
 const CONVERSION_IGNORED_GET_ACTION_TAG = 'CONVERSION_IGNORED';
+const PROPOSAL_NEW_ACTION_TAG = 'PROPOSAL_NEW';
 const WALLET_DELETE_ACTION_TAG = 'WALLET_DELETE';
 const SETTINGS_DELETE_ACTION_TAG = 'SETTINGS_DELETE';
 const CONVERSION_DELETE_ACTION_TAG = 'CONVERSION_DELETE';
+const PROPOSAL_DELETE_ACTION_TAG = 'PROPOSAL_DELETE';
 
 /**
  * THOUGHTS/TODO
@@ -36,6 +39,14 @@ var plugin = {
      * @callback errorCallback
      * @param {string} error - error description
      */
+
+    /**
+     * @readonly
+     * @enum {number}
+     */
+    PayloadType: {
+        PUBLIC: 1
+    },
 
     /**
      * @param {string} mnemonics a string with the mnemonic phrase
@@ -122,6 +133,25 @@ var plugin = {
     },
 
     /**
+     *
+     *
+     * # Errors
+     *
+     * this function may fail if if any of the pointers are is null;
+     * @param {string} walletPtr a pointer to a Wallet object obtained with WalletRestore
+     * @param {string} settingsPtr
+     * @param {string} proposalPtr
+     * @param {number} choice
+     * @param {function} successCallback
+     * @param {function} errorCallback
+     *
+     */
+    walletVote: function (walletPtr, settingsPtr, proposalPtr, choice, successCallback, errorCallback) {
+        argscheck.checkArgs('sssnff', 'walletVote', arguments);
+        exec(successCallback, errorCallback, NATIVE_CLASS_NAME, WALLET_VOTE_ACTION_TAG, [walletPtr, settingsPtr, proposalPtr, choice]);
+    },
+
+    /**
      * @param {string} walletPtr a pointer to a wallet obtained with walletRestore
      * @param {string} settingsPtr a pointer to a settings object obtained with walletRetrieveFunds
      * @param {pointerCallback} successCallback returns a Conversion object
@@ -164,6 +194,23 @@ var plugin = {
     },
 
     /**
+     * @param {string} votePlanId
+     * @param {PayloadType} payloadType
+     * @param {number} index
+     * @param {number} numChoices
+     * @param {function} successCallback returns an object with ignored, and value properties
+     * @param {errorCallback} errorCallback
+     */
+    proposalNew: function (votePlanId, payloadType, index, numChoices, successCallback, errorCallback) {
+        argscheck.checkArgs('*nnnff', 'proposalNew', arguments);
+        if (require('cordova/utils').typeName(votePlanId) === 'Uint8Array') {
+            exec(successCallback, errorCallback, NATIVE_CLASS_NAME, PROPOSAL_NEW_ACTION_TAG, [votePlanId, payloadType, index, numChoices]);
+        } else {
+            throw TypeError('expected votePlanId to be a Uint8Array in proposalNew');
+        }
+    },
+
+    /**
      * @param {string} ptr a pointer to a Wallet obtained with walletRestore
      * @param {function} successCallback  indicates success. Does not return anything.
      * @param {errorCallback} errorCallback
@@ -191,6 +238,16 @@ var plugin = {
     conversionDelete: function (ptr, successCallback, errorCallback) {
         argscheck.checkArgs('sff', 'conversionDelete', arguments);
         exec(successCallback, errorCallback, NATIVE_CLASS_NAME, CONVERSION_DELETE_ACTION_TAG, [ptr]);
+    },
+
+    /**
+     * @param {string} ptr a pointer to a Proposal object obtained with proposalNew
+     * @param {function} successCallback  indicates success. Does not return anything.
+     * @param {errorCallback} errorCallback
+     */
+    proposalDelete: function (ptr, successCallback, errorCallback) {
+        argscheck.checkArgs('sff', 'proposalDelete', arguments);
+        exec(successCallback, errorCallback, NATIVE_CLASS_NAME, PROPOSAL_DELETE_ACTION_TAG, [ptr]);
     }
 };
 

--- a/bindings/wallet-core/src/error.rs
+++ b/bindings/wallet-core/src/error.rs
@@ -47,6 +47,10 @@ pub enum ErrorCode {
 
     /// the provided voting choice is out of the allowed range
     WalletVoteOutOfRange = 4,
+
+    /// the wallet failed to build a valid transaction, for example
+    /// not enough funds available
+    WalletTransactionBuilding = 5,
 }
 
 #[derive(Debug)]
@@ -67,6 +71,9 @@ pub enum ErrorKind {
 
     /// the provided voting choice is out of the allowed range
     WalletVoteOutOfRange,
+
+    /// the wallet failed to build a valid transaction
+    WalletTransactionBuilding,
 }
 
 impl ErrorKind {
@@ -80,6 +87,7 @@ impl ErrorKind {
             Self::WalletRecovering => ErrorCode::WalletRecovering,
             Self::WalletConversion => ErrorCode::WalletConversion,
             Self::WalletVoteOutOfRange => ErrorCode::WalletVoteOutOfRange,
+            Self::WalletTransactionBuilding => ErrorCode::WalletTransactionBuilding,
         }
     }
 }
@@ -149,6 +157,13 @@ impl Error {
     pub fn wallet_vote_range() -> Self {
         Self {
             kind: ErrorKind::WalletVoteOutOfRange,
+            details: None,
+        }
+    }
+
+    pub fn wallet_transaction() -> Self {
+        Self {
+            kind: ErrorKind::WalletTransactionBuilding,
             details: None,
         }
     }
@@ -289,6 +304,9 @@ impl Display for ErrorKind {
             Self::WalletVoteOutOfRange => {
                 f.write_str("The provided choice is out of the vote variants range")
             }
+            Self::WalletTransactionBuilding => f.write_str(
+                "Failed to build a valid transaction, probably not enough funds available",
+            ),
         }
     }
 }

--- a/bindings/wallet-core/src/wallet.rs
+++ b/bindings/wallet-core/src/wallet.rs
@@ -204,7 +204,9 @@ impl Wallet {
 
         let mut builder = wallet::transaction::TransactionBuilder::new(settings, vec![], payload);
         builder.select_from(&mut self.account);
-        let tx = builder.finalize_tx(());
+        let tx = builder
+            .finalize_tx(())
+            .map_err(|e| Error::wallet_transaction().with(e))?;
         let fragment = Fragment::VoteCast(tx);
         Ok(fragment.serialize_as_vec().unwrap().into_boxed_slice())
     }

--- a/bindings/wallet-jni/Cargo.toml
+++ b/bindings/wallet-jni/Cargo.toml
@@ -12,3 +12,4 @@ crate-type = [ "cdylib" ]
 [dependencies]
 jni = "0.16.0"
 wallet-core = { path = "../wallet-core" }
+chain-impl-mockchain = { path = "../../chain-deps/chain-impl-mockchain" }

--- a/bindings/wallet-jni/java/WalletTest.java
+++ b/bindings/wallet-jni/java/WalletTest.java
@@ -1,6 +1,7 @@
 import com.iohk.jormungandrwallet.Wallet;
 import com.iohk.jormungandrwallet.Settings;
 import com.iohk.jormungandrwallet.Conversion;
+import com.iohk.jormungandrwallet.Proposal;
 
 import java.util.Properties;
 import java.util.Enumeration;
@@ -79,6 +80,30 @@ public class WalletTest {
             Conversion.delete(conversionPtr);
             Settings.delete(settingsPtr);
             Wallet.delete(walletPtr);
+            throw e;
+        }
+    }
+
+    @Test
+    public void voteCast() throws IOException {
+        final long walletPtr = Wallet.recover(
+                "neck bulb teach illegal soul cry monitor claw amount boring provide village rival draft stone");
+
+        final byte[] block0 = Files.readAllBytes(Paths.get("../../../test-vectors/block0"));
+
+        final long settingsPtr = Wallet.initialFunds(walletPtr, block0);
+
+        final byte[] id = new byte[Proposal.ID_SIZE];
+        final long proposalPtr = Proposal.withPublicPayload(id, 0, 3);
+
+        Wallet.setState(walletPtr, 10000000, 0);
+        try {
+            final byte[] transaction = Wallet.voteCast(walletPtr, settingsPtr, proposalPtr, 1);
+        } catch (final Exception e) {
+            Proposal.delete(proposalPtr);
+            Settings.delete(settingsPtr);
+            Wallet.delete(walletPtr);
+            System.out.println(e.getMessage());
             throw e;
         }
     }

--- a/bindings/wallet-jni/java/com/iohk/jormungandrwallet/Proposal.java
+++ b/bindings/wallet-jni/java/com/iohk/jormungandrwallet/Proposal.java
@@ -1,0 +1,12 @@
+package com.iohk.jormungandrwallet;
+
+public class Proposal {
+    static {
+        System.loadLibrary("wallet_jni");
+    }
+    public static final int ID_SIZE = 32;
+
+    public native static long withPublicPayload(byte [] votePlanId, int index, int numChoices);
+
+    public native static void delete(long proposalPtr);
+}

--- a/bindings/wallet-jni/java/com/iohk/jormungandrwallet/Wallet.java
+++ b/bindings/wallet-jni/java/com/iohk/jormungandrwallet/Wallet.java
@@ -18,4 +18,6 @@ public class Wallet {
     public native static byte[] id(long wallet);
 
     public native static void setState(long wallet, long value, long counter);
+
+    public native static byte[] voteCast(long wallet, long settings, long proposal, int choice);
 }

--- a/bindings/wallet-jni/src/lib.rs
+++ b/bindings/wallet-jni/src/lib.rs
@@ -1,3 +1,4 @@
+use chain_impl_mockchain::vote::PayloadType;
 use jni::objects::{JClass, JObject, JString, JValue};
 use jni::sys::{jbyte, jbyteArray, jint, jlong};
 use jni::JNIEnv;
@@ -333,4 +334,96 @@ pub extern "system" fn Java_com_iohk_jormungandrwallet_Wallet_setState(
     if let Some(error) = r.error() {
         let _ = env.throw(error.to_string());
     }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_iohk_jormungandrwallet_Proposal_withPublicPayload(
+    env: JNIEnv,
+    _: JClass,
+    vote_plan_id: jbyteArray,
+    index: u8,
+    num_choices: u8,
+) -> jlong {
+    let size = env.get_array_length(vote_plan_id).expect("invalid array");
+
+    let mut buffer = vec![0i8; size as usize];
+    env.get_byte_array_region(vote_plan_id, 0, &mut buffer)
+        .expect("invalid byte arrray read");
+
+    let mut proposal = null_mut();
+    let r = unsafe {
+        wallet_vote_proposal(
+            buffer.as_ptr() as *const u8,
+            PayloadType::Public,
+            index,
+            num_choices,
+            &mut proposal,
+        )
+    };
+
+    debug_assert!(!proposal.is_null());
+
+    if let Some(error) = r.error() {
+        let _ = env.throw(error.to_string());
+    }
+
+    proposal as jlong
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_iohk_jormungandrwallet_Proposal_delete(
+    _: JNIEnv,
+    _: JClass,
+    proposal: jlong,
+) {
+    let proposal = proposal as ProposalPtr;
+    if !proposal.is_null() {
+        wallet_delete_proposal(proposal);
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_iohk_jormungandrwallet_Wallet_voteCast(
+    env: JNIEnv,
+    _: JClass,
+    wallet: jlong,
+    settings: jlong,
+    proposal: jlong,
+    choice: jint,
+) -> jbyteArray {
+    let wallet_ptr = wallet as WalletPtr;
+    let settings_ptr = settings as SettingsPtr;
+    let proposal_ptr = proposal as ProposalPtr;
+
+    let mut transaction_out: *const u8 = null();
+    let mut transaction_size: usize = 0;
+
+    let r = unsafe {
+        wallet_vote_cast(
+            wallet_ptr,
+            settings_ptr,
+            proposal_ptr,
+            choice as u8,
+            &mut transaction_out as *mut *const u8,
+            &mut transaction_size as *mut usize,
+        )
+    };
+
+    if let Some(error) = r.error() {
+        let _ = env.throw(error.to_string());
+        return null_mut() as jbyteArray;
+    }
+
+    let array = env
+        .new_byte_array(transaction_size as jint)
+        .expect("Failed to create new byte array");
+
+    debug_assert!(!transaction_out.is_null());
+    let slice =
+        unsafe { std::slice::from_raw_parts(transaction_out as *const jbyte, transaction_size) };
+
+    env.set_byte_array_region(array, 0, slice)
+        .expect("Couldn't copy array to jvm");
+
+    array
 }

--- a/bindings/wallet-jni/src/lib.rs
+++ b/bindings/wallet-jni/src/lib.rs
@@ -386,8 +386,6 @@ pub extern "system" fn Java_com_iohk_jormungandrwallet_Proposal_withPublicPayloa
         )
     };
 
-    debug_assert!(!proposal.is_null());
-
     if let Some(error) = r.error() {
         let _ = env.throw(error.to_string());
     }
@@ -463,7 +461,7 @@ pub extern "system" fn Java_com_iohk_jormungandrwallet_Wallet_voteCast(
         .expect("Couldn't copy array to jvm");
 
     // wallet_vote_cast leaks the buffer, so we need to deallocate that memory,
-    // as set_byte_array_region does a *copy* of the buffer so we don't need it anymore.
+    // set_byte_array_region does a *copy* of the buffer so we don't need it anymore.
     unsafe { Box::from_raw(slice.as_ptr() as *mut u8) };
 
     array


### PR DESCRIPTION
- Also add the top-level cordova plugin interface with the android implementation.
- Add an error type when in the TransactionBuilder when balance doesn't check, because a panic crashes the app in android (and it's easy to trigger if someone forgets to set the wallet state). Please review that the error report makes sense.