### PR TITLE
Serialize settings

### DIFF
--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -21,8 +21,8 @@ chain-crypto = { path = "../chain-deps/chain-crypto" }
 chain-addr = { path = "../chain-deps/chain-addr" }
 chain-impl-mockchain = { path = "../chain-deps/chain-impl-mockchain" }
 cardano-legacy-address = { path = "../chain-deps/cardano-legacy-address" }
+chain-ser = { path = "../chain-deps/chain-ser" }
 
 [dev-dependencies]
 quickcheck = "0.9"
 quickcheck_macros = "0.9"
-chain-ser = { path = "../chain-deps/chain-ser" }

--- a/wallet/src/blockchain.rs
+++ b/wallet/src/blockchain.rs
@@ -3,13 +3,18 @@ use chain_impl_mockchain::{
     certificate::CertificateSlice,
     chaintypes::HeaderId,
     fee::FeeAlgorithm as _,
-    fee::LinearFee,
+    fee::{LinearFee, PerCertificateFee, PerVoteCertificateFee},
     fragment::Fragment,
+    ledger::recovery::{
+        pack_ledger_static_parameters, pack_time_era, unpack_ledger_static_parameters,
+        unpack_time_era,
+    },
     ledger::{Error, Ledger, LedgerParameters, LedgerStaticParameters},
     transaction::Input,
     value::Value,
     vote::CommitteeId,
 };
+use chain_ser::packer::Codec;
 use chain_time::TimeEra;
 use std::time::{Duration, SystemTime};
 
@@ -81,4 +86,149 @@ impl Settings {
     pub fn block0_hash(&self) -> HeaderId {
         self.static_parameters.block0_initial_hash
     }
+
+    pub fn serialize(&self) -> Result<Box<[u8]>, std::io::Error> {
+        let buf = vec![];
+        let mut codec = Codec::new(buf);
+
+        pack_ledger_static_parameters(&self.static_parameters, &mut codec)
+            .expect("failed to serialize static parameters");
+
+        pack_time_era(&self.time_era, &mut codec)?;
+
+        pack_linear_fee(&self.fees, &mut codec)?;
+
+        codec.put_u64(self.committees.len() as u64)?;
+        for committee in &self.committees {
+            codec.put_bytes(committee.as_ref())?;
+        }
+
+        Ok(codec.into_inner().into_boxed_slice())
+    }
+
+    pub fn deserialize(raw: &[u8]) -> Result<Self, std::io::Error> {
+        let reader = std::io::BufReader::new(raw);
+        let mut codec = Codec::new(reader);
+        let static_parameters = unpack_ledger_static_parameters(&mut codec)?;
+        let time_era = unpack_time_era(&mut codec)?;
+        let fees = unpack_linear_fee(&mut codec)?;
+
+        let committees_len = codec.get_u64()?;
+
+        use std::convert::TryInto;
+        let committees: Result<Vec<CommitteeId>, std::io::Error> = (0..committees_len)
+            .map(|_| {
+                let raw = codec.get_bytes(CommitteeId::COMMITTEE_ID_SIZE)?;
+                let arr: [u8; CommitteeId::COMMITTEE_ID_SIZE] = raw[..].try_into().unwrap();
+
+                Ok(arr.into())
+            })
+            .collect();
+
+        Ok(Settings {
+            static_parameters,
+            time_era,
+            fees,
+            committees: committees?,
+        })
+    }
+}
+
+fn pack_linear_fee<W: std::io::Write>(
+    linear_fee: &LinearFee,
+    codec: &mut Codec<W>,
+) -> Result<(), std::io::Error> {
+    codec.put_u64(linear_fee.constant)?;
+    codec.put_u64(linear_fee.coefficient)?;
+    codec.put_u64(linear_fee.certificate)?;
+    pack_per_certificate_fee(&linear_fee.per_certificate_fees, codec)?;
+    pack_per_vote_certificate_fee(&linear_fee.per_vote_certificate_fees, codec)?;
+    Ok(())
+}
+
+fn unpack_linear_fee<R: std::io::BufRead>(
+    codec: &mut Codec<R>,
+) -> Result<LinearFee, std::io::Error> {
+    let constant = codec.get_u64()?;
+    let coefficient = codec.get_u64()?;
+    let certificate = codec.get_u64()?;
+    let per_certificate_fees = unpack_per_certificate_fee(codec)?;
+    let per_vote_certificate_fees = unpack_per_vote_certificate_fee(codec)?;
+    Ok(LinearFee {
+        constant,
+        coefficient,
+        certificate,
+        per_certificate_fees,
+        per_vote_certificate_fees,
+    })
+}
+
+fn pack_per_certificate_fee<W: std::io::Write>(
+    per_certificate_fee: &PerCertificateFee,
+    codec: &mut Codec<W>,
+) -> Result<(), std::io::Error> {
+    codec.put_u64(
+        per_certificate_fee
+            .certificate_pool_registration
+            .map(|v| v.get())
+            .unwrap_or(0),
+    )?;
+    codec.put_u64(
+        per_certificate_fee
+            .certificate_stake_delegation
+            .map(|v| v.get())
+            .unwrap_or(0),
+    )?;
+    codec.put_u64(
+        per_certificate_fee
+            .certificate_owner_stake_delegation
+            .map(|v| v.get())
+            .unwrap_or(0),
+    )?;
+    Ok(())
+}
+
+fn pack_per_vote_certificate_fee<W: std::io::Write>(
+    per_vote_certificate_fee: &PerVoteCertificateFee,
+    codec: &mut Codec<W>,
+) -> Result<(), std::io::Error> {
+    codec.put_u64(
+        per_vote_certificate_fee
+            .certificate_vote_plan
+            .map(|v| v.get())
+            .unwrap_or(0),
+    )?;
+    codec.put_u64(
+        per_vote_certificate_fee
+            .certificate_vote_cast
+            .map(|v| v.get())
+            .unwrap_or(0),
+    )?;
+    Ok(())
+}
+
+fn unpack_per_certificate_fee<R: std::io::BufRead>(
+    codec: &mut Codec<R>,
+) -> Result<PerCertificateFee, std::io::Error> {
+    let certificate_pool_registration = std::num::NonZeroU64::new(codec.get_u64()?);
+    let certificate_stake_delegation = std::num::NonZeroU64::new(codec.get_u64()?);
+    let certificate_owner_stake_delegation = std::num::NonZeroU64::new(codec.get_u64()?);
+
+    Ok(PerCertificateFee {
+        certificate_pool_registration,
+        certificate_stake_delegation,
+        certificate_owner_stake_delegation,
+    })
+}
+
+fn unpack_per_vote_certificate_fee<R: std::io::BufRead>(
+    codec: &mut Codec<R>,
+) -> Result<PerVoteCertificateFee, std::io::Error> {
+    let certificate_vote_plan = std::num::NonZeroU64::new(codec.get_u64()?);
+    let certificate_vote_cast = std::num::NonZeroU64::new(codec.get_u64()?);
+
+    Ok(PerVoteCertificateFee {
+        certificate_vote_plan,
+        certificate_vote_cast,
+    })
 }

--- a/wallet/src/transaction/builder.rs
+++ b/wallet/src/transaction/builder.rs
@@ -2,7 +2,7 @@ use super::witness_builder::WitnessBuilder;
 use crate::Settings;
 use chain_addr::Address;
 use chain_impl_mockchain::{
-    fee::FeeAlgorithm as _,
+    fee::FeeAlgorithm,
     transaction::{
         Balance, Input, Output, Payload, SetAuthData, SetIOs, SetWitnesses, Transaction,
         TxBuilderState,
@@ -65,7 +65,7 @@ impl<'settings, P: Payload> TransactionBuilder<'settings, P> {
 
     #[inline]
     pub fn estimate_fee_with(&self, extra_inputs: u8, extra_outputs: u8) -> Value {
-        self.settings.parameters.fees.calculate(
+        self.settings.fees.calculate(
             Payload::to_certificate_slice(self.payload.payload_data().borrow()),
             self.inputs.len() as u8 + extra_inputs,
             self.outputs.len() as u8 + extra_outputs,

--- a/wallet/tests/utils/mod.rs
+++ b/wallet/tests/utils/mod.rs
@@ -29,7 +29,8 @@ impl State {
     }
 
     pub fn settings(&self) -> Result<Settings, LedgerError> {
-        Settings::new(&self.block0)
+        let hash = self.block0.header.id();
+        Settings::new(hash, &mut self.block0.contents.iter())
     }
 
     pub fn apply_fragments<'a, F>(&'a mut self, fragments: F) -> Result<(), LedgerError>


### PR DESCRIPTION
relates to #78 
- Keep in the `Settings` only the things that are currently in use.
- Retrieve the funds from fragments and parse the settings in only one pass, although with this (simple) implementation all the fragments will always get processed even if the fund retrieval fails early (but this is not a common case anyway).
- Add `serialize` and `deserialize` functions for the Settings. The idea is to be able to store the `Settings` object in order to avoid processing the whole `block0` after the initial funds retrieval/conversion is done. 

There are no bindings for this yet.
There are some private functions in the chain-libs that could be reused here, but I'm not really sure if we actually want to do that (because in that case implementing Serialize for them may be better?). I don't think it adds too much complexity to define custom serialization here anyway.
