### PR TITLE
set LTO to true in the release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ members = [
 exclude = [
     "chain-deps",
 ]
+
+[profile.release]
+lto = "yes"


### PR DESCRIPTION
Set LTO=yes for whole workspace on the `release` profile.
I think this solves the release issues, although I'm not sure if it is a reasonable decision for a library.

I think the problem is that when the c-bindings crate (jormungandrwallet) with `cargo rustc -- --LTO` doesn't mean that the `wallet` crate builds with LTO, as the `rustc` command doesn't forward compilation flags to the dependencies, so the `wallet` crate doesn't have the bitcode embedded.

It may be also possible to set this with environment variables only for release?