### PR TITLE
enable mutable globals in wasm-opt

### DIFF
--- a/bindings/wallet-js/Cargo.toml
+++ b/bindings/wallet-js/Cargo.toml
@@ -45,3 +45,7 @@ wasm-bindgen-test = "0.2"
 [profile.release]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
+
+# See https://github.com/rustwasm/wasm-pack/issues/886
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O", "--enable-mutable-globals"]


### PR DESCRIPTION
The release pipeline is broken for cordova (the webassembly part)
Workaround taken from https://github.com/rustwasm/wasm-pack/issues/886

Maybe we should include more things in the integration checks.