### PR TITLE
Fix free key derivation hack

### DIFF
--- a/wallet/src/scheme/bip44.rs
+++ b/wallet/src/scheme/bip44.rs
@@ -22,7 +22,7 @@ const DEFAULT_GAG_LIMIT: u32 = 20;
 
 pub struct Wallet<A: 'static> {
     coin_type_key: Key<XPrv, Bip44<bip44::CoinType>>,
-    state: States<FragmentId, UtxoStore<XPrv, Bip44<bip44::Address>>>,
+    state: States<FragmentId, UtxoStore<Key<XPrv, Bip44<bip44::Address>>>>,
     soft_derivation_range_length: u32,
     mk_key: &'static dyn Fn(&XPub) -> A,
     accounts: Vec<Account<A>>,
@@ -151,7 +151,7 @@ impl<A> Wallet<A> {
     }
 
     /// get the utxos of this given wallet
-    pub fn utxos(&self) -> &UtxoStore<XPrv, Bip44<bip44::Address>> {
+    pub fn utxos(&self) -> &UtxoStore<Key<XPrv, Bip44<bip44::Address>>> {
         self.state.last_state().1
     }
 }

--- a/wallet/src/scheme/rindex.rs
+++ b/wallet/src/scheme/rindex.rs
@@ -23,7 +23,7 @@ use hdkeygen::{
 pub struct Wallet {
     root_key: Key<XPrv, Rindex<rindex::Root>>,
     payload_key: HDKey,
-    state: States<FragmentId, UtxoStore<XPrv, Rindex<rindex::Address>>>,
+    state: States<FragmentId, UtxoStore<Key<XPrv, Rindex<rindex::Address>>>>,
 }
 
 impl Wallet {
@@ -37,7 +37,7 @@ impl Wallet {
     }
 
     /// get the utxos of this given wallet
-    pub fn utxos(&self) -> &UtxoStore<XPrv, Rindex<rindex::Address>> {
+    pub fn utxos(&self) -> &UtxoStore<Key<XPrv, Rindex<rindex::Address>>> {
         self.state.last_state().1
     }
 

--- a/wallet/src/store/mod.rs
+++ b/wallet/src/store/mod.rs
@@ -1,3 +1,3 @@
 mod utxo;
 
-pub use self::utxo::{UtxoGroup, UtxoStore};
+pub use self::utxo::{GroupKey, UtxoGroup, UtxoStore};

--- a/wallet/src/store/mod.rs
+++ b/wallet/src/store/mod.rs
@@ -1,3 +1,3 @@
 mod utxo;
 
-pub use self::utxo::{GroupKey, UtxoGroup, UtxoStore};
+pub use self::utxo::{Groupable, UtxoGroup, UtxoStore};

--- a/wallet/src/transaction/dump.rs
+++ b/wallet/src/transaction/dump.rs
@@ -1,4 +1,4 @@
-use crate::store::{GroupKey, UtxoStore};
+use crate::store::{Groupable, UtxoStore};
 
 use super::builder::{AddInputStatus, TransactionBuilder};
 use super::witness_builder::{OldUtxoWitnessBuilder, UtxoWitnessBuilder, WitnessBuilder};
@@ -18,7 +18,7 @@ pub type DumpIcarus<'a> =
     DumpIter<'a, crate::scheme::bip44::Wallet<chain_impl_mockchain::legacy::OldAddress>>;
 pub type DumpFreeKeys<'a> = DumpIter<'a, crate::scheme::freeutxo::Wallet>;
 
-pub fn send_to_one_address<K: Clone + GroupKey, WB: WitnessBuilder>(
+pub fn send_to_one_address<K: Clone + Groupable, WB: WitnessBuilder>(
     settings: &crate::Settings,
     address: &chain_addr::Address,
     utxo_store: &UtxoStore<K>,

--- a/wallet/src/transaction/dump.rs
+++ b/wallet/src/transaction/dump.rs
@@ -1,4 +1,4 @@
-use crate::store::UtxoStore;
+use crate::store::{GroupKey, UtxoStore};
 
 use super::builder::{AddInputStatus, TransactionBuilder};
 use super::witness_builder::{OldUtxoWitnessBuilder, UtxoWitnessBuilder, WitnessBuilder};
@@ -18,11 +18,11 @@ pub type DumpIcarus<'a> =
     DumpIter<'a, crate::scheme::bip44::Wallet<chain_impl_mockchain::legacy::OldAddress>>;
 pub type DumpFreeKeys<'a> = DumpIter<'a, crate::scheme::freeutxo::Wallet>;
 
-pub fn send_to_one_address<S: Clone, K: 'static, WB: WitnessBuilder>(
+pub fn send_to_one_address<K: Clone + GroupKey, WB: WitnessBuilder>(
     settings: &crate::Settings,
     address: &chain_addr::Address,
-    utxo_store: &UtxoStore<S, K>,
-    mk_witness: &'static dyn Fn(hdkeygen::Key<S, K>) -> WB,
+    utxo_store: &UtxoStore<K>,
+    mk_witness: &'static dyn Fn(K) -> WB,
 ) -> Option<(Transaction<NoExtra>, Vec<Input>)> {
     let payload = chain_impl_mockchain::transaction::NoExtra;
 


### PR DESCRIPTION
This changes the UtxoStore generics arguments to be able to use `SecretKey` instead of `Key`, which is used for the free keys. As the free keys have no derivation, they are not grouped by derivation path in the utxo store, but by public key (before this, they had a fake derivation path given by the order they were recovered).