### PR TITLE
add wallet-js bundler target

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [nodejs, web]
+        target: [nodejs, web, bundler]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -138,6 +138,11 @@ jobs:
 
       - name: build
         run: wasm-pack build --release --target ${{ matrix.target }} bindings/wallet-js
+
+      # FIXME: this shouldn't be necessary, investigate further
+      - name: patch package.json missing file
+        working-directory: ./bindings/wallet-js
+        run: sh patch-packaging.sh 
 
       - name: pack
         run: wasm-pack pack bindings/wallet-js

--- a/bindings/wallet-js/patch-packaging.sh
+++ b/bindings/wallet-js/patch-packaging.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+## FIXME: Technical debt, find the real issue in wasm-pack.
+## For some reason this file is missing from the 'files' entry in package.json,
+## causing the file not to be included in the build, which at least fails for
+## the bundle target.
+
+cat pkg/package.json | jq '.files |= (.+ ["wallet_js_bg.js"] | unique)' > tmp.json
+mv tmp.json pkg/package.json


### PR DESCRIPTION
add a temporal? patch for the fact that wasm-pack is not including the
'_bg.js' file in the package.json