### PR TITLE
wallet-js generate key from seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### wallet-js
+
+- Add Ed25519Extended generation from seed
+
 ## [0.5.0-pre4] - 2020-10-13
 
 ### Added

--- a/bindings/wallet-js/tests/web.rs
+++ b/bindings/wallet-js/tests/web.rs
@@ -46,3 +46,24 @@ fn encrypt_decrypt() {
         &data[..]
     );
 }
+
+#[wasm_bindgen_test]
+fn gen_key_from_seed() {
+    let seed1 = [1u8; 32];
+    let key1 = Ed25519ExtendedPrivate::from_seed(seed1.as_ref()).unwrap();
+    let key2 = Ed25519ExtendedPrivate::from_seed(seed1.as_ref()).unwrap();
+
+    assert_eq!(key1.bytes(), key2.bytes());
+
+    let seed2 = [2u8; 32];
+    let key3 = Ed25519ExtendedPrivate::from_seed(seed2.as_ref()).unwrap();
+
+    assert_ne!(key3.bytes(), key1.bytes());
+}
+
+#[wasm_bindgen_test]
+fn gen_key_from_invalid_seed_fails() {
+    const INVALID_SEED_SIZE: usize = 32 + 1;
+    let bad_seed = [2u8; INVALID_SEED_SIZE];
+    assert!(Ed25519ExtendedPrivate::from_seed(bad_seed.as_ref()).is_err())
+}


### PR DESCRIPTION
Add option to generate keys from seed. Which is useful for testing.