### PR TITLE
Remove im-rc

### DIFF
--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -14,6 +14,7 @@ bip39 = { path = "../bip39" }
 chain-path-derivation = { path = "../chain-path-derivation" }
 hdkeygen = { path = "../hdkeygen" }
 hex = "0.4.2"
+itertools = "0.9"
 
 chain-time = { path = "../chain-deps/chain-time" }
 chain-crypto = { path = "../chain-deps/chain-crypto" }
@@ -21,7 +22,6 @@ chain-addr = { path = "../chain-deps/chain-addr" }
 chain-impl-mockchain = { path = "../chain-deps/chain-impl-mockchain" }
 cardano-legacy-address = { path = "../chain-deps/cardano-legacy-address" }
 imhamt = { path = "../chain-deps/imhamt" }
-itertools = "0.9"
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -14,7 +14,6 @@ bip39 = { path = "../bip39" }
 chain-path-derivation = { path = "../chain-path-derivation" }
 hdkeygen = { path = "../hdkeygen" }
 hex = "0.4.2"
-im-rc = "15.0.0"
 
 chain-time = { path = "../chain-deps/chain-time" }
 chain-crypto = { path = "../chain-deps/chain-crypto" }
@@ -22,6 +21,7 @@ chain-addr = { path = "../chain-deps/chain-addr" }
 chain-impl-mockchain = { path = "../chain-deps/chain-impl-mockchain" }
 cardano-legacy-address = { path = "../chain-deps/cardano-legacy-address" }
 imhamt = { path = "../chain-deps/imhamt" }
+itertools = "0.9"
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -21,6 +21,7 @@ chain-crypto = { path = "../chain-deps/chain-crypto" }
 chain-addr = { path = "../chain-deps/chain-addr" }
 chain-impl-mockchain = { path = "../chain-deps/chain-impl-mockchain" }
 cardano-legacy-address = { path = "../chain-deps/cardano-legacy-address" }
+imhamt = { path = "../chain-deps/imhamt" }
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/wallet/src/store/utxo.rs
+++ b/wallet/src/store/utxo.rs
@@ -129,8 +129,6 @@ impl<K> UtxoGroup<K> {
     }
 
     fn remove(&self, utxo: &UtxoPointer) -> Self {
-        // let mut new = self.clone();
-
         let Self {
             by_value,
             mut total_value,

--- a/wallet/src/store/utxo.rs
+++ b/wallet/src/store/utxo.rs
@@ -255,10 +255,6 @@ impl<KEY: Groupable> UtxoStore<KEY> {
             })
             .unwrap();
 
-        // new.by_value.entry(utxo.value).and_modify(|set| {
-        //     *set = set.remove(&utxo);
-        // });
-
         new.by_value = new
             .by_value
             .update::<_, std::convert::Infallible>(&utxo.value, |set| Ok(Some(set.remove(&utxo))))

--- a/wallet/src/store/utxo.rs
+++ b/wallet/src/store/utxo.rs
@@ -239,9 +239,7 @@ impl<K: Groupable> UtxoStore<K> {
     pub fn remove(&self, utxo: &UtxoPointer) -> Option<Self> {
         let mut new = self.clone();
 
-        let utxo = Rc::new(*utxo);
-
-        let group = new.by_utxo.lookup(&utxo)?;
+        let group = new.by_utxo.lookup(utxo)?;
         let path = group.key.group_key();
 
         new.by_utxo.remove(&Rc::new(*utxo)).ok()?;
@@ -255,7 +253,9 @@ impl<K: Groupable> UtxoStore<K> {
 
         new.by_value = new
             .by_value
-            .update::<_, std::convert::Infallible>(&utxo.value, |set| Ok(Some(set.remove(&utxo))))
+            .update::<_, std::convert::Infallible>(&utxo.value, |set| {
+                Ok(Some(set.remove(&Rc::new(utxo.clone()))))
+            })
             .unwrap();
 
         new.total_value = new

--- a/wallet/src/store/utxo.rs
+++ b/wallet/src/store/utxo.rs
@@ -137,7 +137,7 @@ impl<K> UtxoGroup<K> {
 
         let by_value = by_value
             .update::<_, std::convert::Infallible>(&utxo.value, |set| {
-                let new_set = set.remove(&Rc::new(utxo.clone()));
+                let new_set = set.remove(utxo);
 
                 total_value = total_value
                     .checked_sub(utxo.value)
@@ -242,12 +242,12 @@ impl<K: Groupable> UtxoStore<K> {
         let group = new.by_utxo.lookup(utxo)?;
         let path = group.key.group_key();
 
-        new.by_utxo.remove(&Rc::new(*utxo)).ok()?;
+        new.by_utxo.remove(utxo).ok()?;
 
         new.by_derivation_path = new
             .by_derivation_path
             .update::<_, std::convert::Infallible>(&path, |group| {
-                Ok(Some(Rc::new(group.remove(&utxo))))
+                Ok(Some(Rc::new(group.remove(utxo))))
             })
             .unwrap();
 
@@ -319,7 +319,11 @@ impl<T: Hash + PartialEq + Eq + Clone> HashSet<T> {
     }
 
     #[must_use = "this structure is immutable, the new one is returned"]
-    fn remove(&self, element: &T) -> Self {
+    fn remove<Q>(&self, element: &Q) -> Self
+    where
+        T: std::borrow::Borrow<Q>,
+        Q: Hash + PartialEq + Eq,
+    {
         Self(self.0.remove(element).unwrap_or(self.0.clone()))
     }
 }


### PR DESCRIPTION
Use imhamt instead of im-rc

As a possible solution to #112 (at least in the short term)

The idea is to replace the im-rc (HashMap, OrdMap) with the imhamt, which (safe or not) is used everywhere already. The `OrdMap` can't really be replaced, but we can just sort a `Vec` as we are not really working with large amounts of utxos at the moment.

Later down the road we can benchmark and optimize if it is a problem, and anyway we may need to change things when (if?) we start considering persistent storage for the utxo store.

Also, remove the `RefCell` which I'm not sure what was for.