### PR TITLE
add cordova plugin status to plugin readme

### DIFF
--- a/bindings/wallet-cordova/README.md
+++ b/bindings/wallet-cordova/README.md
@@ -58,6 +58,36 @@ function onDeviceReady() {
 }
 ```
 
-# Electron quirks
+## Electron quirks
 
 At the moment, the plugin requires that node integrations are enabled in the app.
+
+
+# Implemented API's per platform
+
+|                              | Android | Ios | Electron/browser |
+| ---------------------------- | ------- | --- | ---------------- |
+| CONVERSION_DELETE            | ✓       | ✓   | ✓                |
+| CONVERSION_IGNORED           | ✓       | ✓   | ✓                |
+| CONVERSION_TRANSACTIONS_GET  | ✓       | ✓   | ✓                |
+| CONVERSION_TRANSACTIONS_SIZE | ✓       | ✓   | ✓                |
+| PENDING_TRANSACTIONS_DELETE  | ✓       |     |                  |
+| PENDING_TRANSACTIONS_GET     | ✓       |     |                  |
+| PENDING_TRANSACTIONS_SIZE    | ✓       |     |                  |
+| PROPOSAL_DELETE              | ✓       | ✓   | ✓                |
+| PROPOSAL_NEW                 | ✓       | ✓   | ✓                |
+| PROPOSAL_NEW_PRIVATE         | ✓       | ✓   |                  |
+| PROPOSAL_NEW_PUBLIC          | ✓       | ✓   |                  |
+| SETTINGS_DELETE              | ✓       | ✓   | ✓                |
+| SYMMETRIC_CIPHER_DECRYPT     | ✓       | ✓   |                  |
+| WALLET_CONFIRM_TRANSACTION   | ✓       |     |                  |
+| WALLET_CONVERT               | ✓       | ✓   | ✓                |
+| WALLET_DELETE                | ✓       | ✓   | ✓                |
+| WALLET_ID                    | ✓       | ✓   | ✓                |
+| WALLET_IMPORT_KEYS           | ✓       | ✓   |                  |
+| WALLET_PENDING_TRANSACTIONS  | ✓       |     |                  |
+| WALLET_RESTORE               | ✓       | ✓   | ✓                |
+| WALLET_RETRIEVE_FUNDS        | ✓       | ✓   | ✓                |
+| WALLET_SET_STATE             | ✓       | ✓   | ✓                |
+| WALLET_TOTAL_FUNDS           | ✓       | ✓   | ✓                |
+| WALLET_VOTE                  | ✓       | ✓   | ✓                |


### PR DESCRIPTION
Although I'm already keeping track of things in the changelog, I think having this table somewhere is useful. This is the plugin's subdirectory readme, so it is not really that visible, but I think it's too much information for the main one.

I'll try to fill all of the checkboxes soon, but just in case.