### PR TITLE
Put wallet-js package into @iohk-jormungandr scope

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -144,7 +144,7 @@ jobs:
             --release --target ${{ matrix.target }} \
             bindings/wallet-js
 
-      # FIXME: this shouldn't be necessary, investigate further
+      # https://github.com/rustwasm/wasm-pack/issues/837
       - name: patch package.json missing file
         working-directory: ./bindings/wallet-js
         run: sh patch-packaging.sh 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,7 +137,12 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: build
-        run: wasm-pack build --release --target ${{ matrix.target }} bindings/wallet-js
+        run: |
+          wasm-pack build \
+            --scope iohk-jormungandr \
+            --out-name wallet \
+            --release --target ${{ matrix.target }} \
+            bindings/wallet-js
 
       # FIXME: this shouldn't be necessary, investigate further
       - name: patch package.json missing file

--- a/bindings/wallet-js/patch-packaging.sh
+++ b/bindings/wallet-js/patch-packaging.sh
@@ -1,9 +1,7 @@
 #!/bin/sh -e
 
-## FIXME: Technical debt, find the real issue in wasm-pack.
-## For some reason this file is missing from the 'files' entry in package.json,
-## causing the file not to be included in the build, which at least fails for
-## the bundle target.
+# package.json needs to be fixed up due to a known issue in wasm-pack:
+# https://github.com/rustwasm/wasm-pack/issues/837
 
 cat pkg/package.json | jq '.files |= (.+ ["wallet_bg.js"] | unique)' > tmp.json
 mv tmp.json pkg/package.json

--- a/bindings/wallet-js/patch-packaging.sh
+++ b/bindings/wallet-js/patch-packaging.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env sh
+#!/bin/sh -e
 
 ## FIXME: Technical debt, find the real issue in wasm-pack.
 ## For some reason this file is missing from the 'files' entry in package.json,
 ## causing the file not to be included in the build, which at least fails for
 ## the bundle target.
 
-cat pkg/package.json | jq '.files |= (.+ ["wallet_js_bg.js"] | unique)' > tmp.json
+cat pkg/package.json | jq '.files |= (.+ ["wallet_bg.js"] | unique)' > tmp.json
 mv tmp.json pkg/package.json


### PR DESCRIPTION
It would be cheeky to publish something named `wallet-js` into the global npm namespace.
Give it a scope that I have secured control on at npmjs.com.