### PR TITLE
Convert chain-libs submodule to git dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "chain-deps"]
-	path = chain-deps
-	url = https://github.com/input-output-hk/chain-libs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,5 @@ members = [
     "bindings/wallet-js",
 ]
 
-exclude = [
-    "chain-deps",
-]
-
 [profile.release]
 lto = "yes"

--- a/bindings/wallet-c/Cargo.toml
+++ b/bindings/wallet-c/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["staticlib", "cdylib"]
 [dependencies]
 bip39 = { path = "../../bip39" }
 wallet = { path = "../../wallet" }
-chain-ser = { path = "../../chain-deps/chain-ser" }
-chain-addr = { path = "../../chain-deps/chain-addr" }
-chain-impl-mockchain = { path = "../../chain-deps/chain-impl-mockchain" }
+chain-ser = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-addr = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 wallet-core = { path = "../wallet-core"}

--- a/bindings/wallet-core/Cargo.toml
+++ b/bindings/wallet-core/Cargo.toml
@@ -12,13 +12,13 @@ crate-type = ["lib"]
 
 [dependencies]
 bip39 = {path = "../../bip39"}
-chain-addr = {path = "../../chain-deps/chain-addr"}
-chain-core = {path = "../../chain-deps/chain-core"}
-chain-crypto = {path = "../../chain-deps/chain-crypto"}
-chain-impl-mockchain = {path = "../../chain-deps/chain-impl-mockchain"}
+chain-addr = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-core = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-crypto = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 chain-path-derivation = {path = "../../chain-path-derivation"}
-chain-ser = {path = "../../chain-deps/chain-ser"}
-chain-vote = {path = "../../chain-deps/chain-vote"}
+chain-ser = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-vote = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 hdkeygen = {path = "../../hdkeygen"}
 symmetric-cipher = {path = "../../symmetric-cipher"}
 thiserror = {version = "1.0.13", default-features = false}

--- a/bindings/wallet-core/src/vote.rs
+++ b/bindings/wallet-core/src/vote.rs
@@ -1,6 +1,6 @@
 use chain_impl_mockchain::{
     certificate::{VoteCast, VotePlanId},
-    vote::{Choice, Options, Payload},
+    vote::{self, Choice, Options, Payload},
 };
 pub use chain_vote::EncryptingVoteKey;
 use chain_vote::Vote;
@@ -77,7 +77,7 @@ impl Proposal {
                 let choice = choice.as_byte() - self.options.choice_range().start;
 
                 let vote = Vote::new(length.into(), choice.into());
-                let (encrypted_vote, proof) = chain_vote::encrypt_vote(&mut rng, key, vote);
+                let (encrypted_vote, proof) = vote::encrypt_vote(&mut rng, key, vote);
 
                 Payload::Private {
                     encrypted_vote,

--- a/bindings/wallet-jni/Cargo.toml
+++ b/bindings/wallet-jni/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = [ "cdylib" ]
 [dependencies]
 jni = "0.16.0"
 wallet-core = { path = "../wallet-core" }
-chain-impl-mockchain = { path = "../../chain-deps/chain-impl-mockchain" }
+chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }

--- a/bindings/wallet-js/Cargo.toml
+++ b/bindings/wallet-js/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-chain-crypto = {path = "../../chain-deps/chain-crypto"}
-chain-vote = {path = "../../chain-deps/chain-vote"}
+chain-crypto = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-vote = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 getrandom = {version = "0.1.14", features = ["wasm-bindgen"]}
 rand = "0.7.3"
 rand_chacha = "0.2.2"

--- a/hdkeygen/Cargo.toml
+++ b/hdkeygen/Cargo.toml
@@ -14,9 +14,9 @@ thiserror = { version = "1.0.13", default-features = false }
 chain-path-derivation = { path = "../chain-path-derivation" }
 hex = "0.4.2"
 
-chain-crypto = { path = "../chain-deps/chain-crypto" }
-chain-addr = { path = "../chain-deps/chain-addr" }
-cardano-legacy-address = { path = "../chain-deps/cardano-legacy-address" }
+chain-crypto = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-addr = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+cardano-legacy-address = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -16,14 +16,14 @@ hdkeygen = { path = "../hdkeygen" }
 hex = "0.4.2"
 itertools = "0.9"
 
-chain-time = { path = "../chain-deps/chain-time" }
-chain-crypto = { path = "../chain-deps/chain-crypto" }
-chain-addr = { path = "../chain-deps/chain-addr" }
-chain-impl-mockchain = { path = "../chain-deps/chain-impl-mockchain" }
-cardano-legacy-address = { path = "../chain-deps/cardano-legacy-address" }
-imhamt = { path = "../chain-deps/imhamt" }
+chain-time = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-crypto = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-addr = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+chain-impl-mockchain = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+cardano-legacy-address = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
+imhamt = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 
 [dev-dependencies]
 quickcheck = "0.9"
 quickcheck_macros = "0.9"
-chain-ser = { path = "../chain-deps/chain-ser" }
+chain-ser = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }

--- a/wallet/src/blockchain.rs
+++ b/wallet/src/blockchain.rs
@@ -56,6 +56,6 @@ impl Settings {
     }
 
     pub fn committee(&self) -> &[CommitteeId] {
-        self.parameters.committees.as_slice()
+        &self.parameters.committees
     }
 }


### PR DESCRIPTION
This will normalize chain-libs crates in the dependency graph of projects that use both chain-wallet-libs and chain-libs directly.

Resolves #117