### PR TITLE
Add key generation and pin encryption lib

### DIFF
--- a/.github/workflows/ci_checks.yaml
+++ b/.github/workflows/ci_checks.yaml
@@ -99,6 +99,21 @@ jobs:
       - name: Test in firefox
         run: wasm-pack test --headless --firefox ./bindings/wallet-js
 
+  test-key-gen-lib:
+    name: Wasm-pack test key gen and encryption lib
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install wasm pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Test in chrome
+        run: wasm-pack test --headless --chrome ./keygen
+
   eslint-cordova-plugin:
     name: check eslint for cordova plugin
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -179,6 +179,57 @@ jobs:
           file_glob: true
           overwrite: true
 
+  release_keygen:
+    name: Release catalyst keygen/pincode wasm assets
+    needs: initial_release
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [bundler]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install wasm pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: build
+        run: |
+          wasm-pack build \
+            --scope iohk-jormungandr \
+            --out-name keygen \
+            --release --target ${{ matrix.target }} \
+           keygen
+
+      # https://github.com/rustwasm/wasm-pack/issues/837
+      - name: patch package.json missing file
+        working-directory: ./keygen
+        run: sh patch-packaging.sh 
+
+      - name: pack
+        run: wasm-pack pack keygen
+
+      - name: Get tag version
+        id: get_version
+        run: echo ::set-output name=VERSION::``${GITHUB_REF#refs/tags/}``
+        shell: bash
+
+      - name: rename-tarball
+        run: find ./keygen/pkg -name iohk-jormungandr-keygen*.tgz -exec mv {} iohk-jormungandr-keygen-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target }}.tgz \;
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: iohk-jormungandr-keygen-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target }}.*
+          asset_name: iohk-jormungandr-keygen-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target }}
+          tag: ${{ github.ref }}
+          file_glob: true
+          overwrite: true
+
   build_jni_assets:
     name: Build android jni wallet ${{ matrix.config.os }}
     needs: initial_release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.5.0-pre8] - 2020-12-04
+
+#### wallet-js
+
+- Remove `symmetric_encrypt` (moved to *keygen*)
+- Remove `symmetric_decrypt` (moved to *keygen*)
+- Remove `bech32_decode_to_bytes` (moved to *keygen*)
+
+#### keygen
+
+Add specific package used for daedalus catalyst
+
+*Features*
+
+- Generate Ed25519Extended private/public keys.
+- Encrypt keys with pin.
+- Decode bech32 strings.
+
 ## [0.5.0-pre7] - 2020-11-16
 
 #### wallet-js

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "bindings/wallet-c",
     "bindings/wallet-jni",
     "bindings/wallet-js",
+    "keygen",
 ]
 
 [profile.release]

--- a/bindings/wallet-c/Cargo.toml
+++ b/bindings/wallet-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jormungandrwallet"
-version = "0.4.0"
+version = "0.5.0-pre8"
 authors = ["Nicolas Di Prima <nicolas@primetype.co.uk>", "Vincent Hanquez <vincent@typed.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/bindings/wallet-cordova/tests/plugin.xml
+++ b/bindings/wallet-cordova/tests/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="wallet-cordova-plugin-tests"
-    version="0.5.0-pre7">
+    version="0.5.0-pre8">
     <name>Wallet cordova plugin tests</name>
     <license>Apache 2.0 OR MIT</license>
 

--- a/bindings/wallet-core/Cargo.toml
+++ b/bindings/wallet-core/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nicolas Di Prima <nicolas@primetype.co.uk>", "Vincent Hanquez <vince
 edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "wallet-core"
-version = "0.5.0-pre7"
+version = "0.5.0-pre8"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/bindings/wallet-jni/Cargo.toml
+++ b/bindings/wallet-jni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet-jni"
-version = "0.5.0-pre7"
+version = "0.5.0-pre8"
 authors = ["Daniel Sanchez Quiros <daniel.sanchez@iohk.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/bindings/wallet-js/Cargo.toml
+++ b/bindings/wallet-js/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "wallet-js"
 repository = "https://github.com/input-output-hk/chain-wallet-libs"
-version = "0.5.0-pre7"
+version = "0.5.0-pre8"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/bindings/wallet-js/src/lib.rs
+++ b/bindings/wallet-js/src/lib.rs
@@ -297,18 +297,6 @@ impl Ed25519Signature {
     }
 }
 
-#[wasm_bindgen]
-pub fn symmetric_encrypt(password: &[u8], data: &[u8]) -> Result<Box<[u8]>, JsValue> {
-    symmetric_cipher::encrypt(password, data, rand::rngs::OsRng)
-        .map_err(|e| JsValue::from_str(&format!("encryption failed {}", e)))
-}
-
-#[wasm_bindgen]
-pub fn symmetric_decrypt(password: &[u8], data: &[u8]) -> Result<Box<[u8]>, JsValue> {
-    symmetric_cipher::decrypt(password, data)
-        .map_err(|e| JsValue::from_str(&format!("decryption failed {}", e)))
-}
-
 #[macro_export]
 macro_rules! impl_public_key {
     ($name:ident, $wrapped_type:ty) => {
@@ -407,12 +395,4 @@ impl EncryptingVoteKey {
             .ok_or_else(|| JsValue::from_str("invalid binary format"))
             .map(Self)
     }
-}
-
-#[wasm_bindgen]
-/// decode a bech32 string to a byte array, disregarding the hrp
-pub fn bech32_decode_to_bytes(input: &str) -> Result<Vec<u8>, JsValue> {
-    bech32::decode(input)
-        .and_then(|(_hrp, words)| bech32::FromBase32::from_base32(&words))
-        .map_err(|err| JsValue::from_str(&format!("{}", err)))
 }

--- a/bindings/wallet-js/tests/web.rs
+++ b/bindings/wallet-js/tests/web.rs
@@ -37,17 +37,6 @@ fn gen_key() {
 }
 
 #[wasm_bindgen_test]
-fn encrypt_decrypt() {
-    let data = [1u8; 64 * 2];
-    let password = [1u8, 2, 3, 4];
-    let encrypted = symmetric_encrypt(&password, &data).unwrap();
-    assert_eq!(
-        &symmetric_decrypt(&password, &encrypted).unwrap()[..],
-        &data[..]
-    );
-}
-
-#[wasm_bindgen_test]
 fn gen_key_from_seed() {
     let seed1 = [1u8; 32];
     let key1 = Ed25519ExtendedPrivate::from_seed(seed1.as_ref()).unwrap();

--- a/keygen/.gitignore
+++ b/keygen/.gitignore
@@ -1,0 +1,6 @@
+/target
+**/*.rs.bk
+Cargo.lock
+bin/
+pkg/
+wasm-pack.log

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+authors = ["Enzo Cioppettini <ecioppettini@atixlabs.com>"]
+description = """utility library used to generate and encrypt single utxo
+keys to interact with the wallet from third party applications
+"""
+edition = "2018"
+license = "MIT OR Apache-2.0"
+name = "keygen"
+repository = "https://github.com/input-output-hk/chain-wallet-libs"
+version = "0.5.0-pre7"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["console_error_panic_hook"]
+
+[dependencies]
+bech32 = "0.7.2"
+chain-crypto = {git = "https://github.com/input-output-hk/chain-libs.git", branch = "master"}
+getrandom = {version = "0.1.14", features = ["wasm-bindgen"]}
+js-sys = "0.3.40"
+rand = "0.7.3"
+rand_chacha = "0.2.2"
+symmetric-cipher = {path = "../symmetric-cipher"}
+wasm-bindgen = "0.2"
+
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
+# code size when deploying.
+console_error_panic_hook = {version = "0.1.1", optional = true}
+
+# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
+# compared to the default allocator's ~10K. It is slower than the default
+# allocator, however.
+#
+# Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
+wee_alloc = {version = "0.4.2", optional = true}
+
+# clear_on_drop is a dependency of ed25519_dalek
+# The default can't be compiled to wasm, so it's necessary to enable either the 'nightly'
+# feature or this one.
+clear_on_drop = {version = "0.2", features = ["no_cc"]}
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+[profile.release]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"
+
+# See https://github.com/rustwasm/wasm-pack/issues/886
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O4", "--enable-mutable-globals"]

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "keygen"
 repository = "https://github.com/input-output-hk/chain-wallet-libs"
-version = "0.5.0-pre7"
+version = "0.5.0-pre8"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/keygen/LICENSE-APACHE
+++ b/keygen/LICENSE-APACHE
@@ -1,0 +1,13 @@
+Copyright (c) 2018-2020 Input Output HK
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/keygen/LICENSE-MIT
+++ b/keygen/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018-2020 Input Output HK
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/keygen/patch-packaging.sh
+++ b/keygen/patch-packaging.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+
+# package.json needs to be fixed up due to a known issue in wasm-pack:
+# https://github.com/rustwasm/wasm-pack/issues/837
+
+cat pkg/package.json | jq '.files |= (.+ ["keygen_bg.js"] | unique)' > tmp.json
+mv tmp.json pkg/package.json

--- a/keygen/src/lib.rs
+++ b/keygen/src/lib.rs
@@ -45,9 +45,6 @@ impl Ed25519ExtendedPrivate {
 }
 
 #[wasm_bindgen]
-pub struct Ed25519Signature(chain_crypto::Signature<Box<[u8]>, chain_crypto::Ed25519>);
-
-#[wasm_bindgen]
 pub struct Ed25519Public(chain_crypto::PublicKey<chain_crypto::Ed25519>);
 
 #[wasm_bindgen]

--- a/keygen/src/lib.rs
+++ b/keygen/src/lib.rs
@@ -1,0 +1,83 @@
+use rand_chacha::rand_core::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use std::convert::TryInto;
+
+use wasm_bindgen::prelude::*;
+
+mod utils;
+pub use utils::set_panic_hook;
+
+#[cfg(feature = "wee_alloc")]
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
+#[wasm_bindgen]
+pub struct Ed25519ExtendedPrivate(chain_crypto::SecretKey<chain_crypto::Ed25519Extended>);
+
+#[wasm_bindgen]
+impl Ed25519ExtendedPrivate {
+    pub fn generate() -> Ed25519ExtendedPrivate {
+        Self(chain_crypto::SecretKey::<chain_crypto::Ed25519Extended>::generate(rand::rngs::OsRng))
+    }
+
+    /// optional seed to generate the key, for the same entropy the same key will be generated (32
+    /// bytes). This seed will be fed to ChaChaRNG and allow pseudo random key
+    /// generation. Do not use if you are not sure
+    pub fn from_seed(seed: &[u8]) -> Result<Ed25519ExtendedPrivate, JsValue> {
+        let seed: [u8; 32] = seed
+            .try_into()
+            .map_err(|_| JsValue::from_str("Invalid seed, expected 32 bytes"))?;
+
+        let rng = ChaCha20Rng::from_seed(seed);
+
+        Ok(Self(
+            chain_crypto::SecretKey::<chain_crypto::Ed25519Extended>::generate(rng),
+        ))
+    }
+
+    pub fn public(&self) -> Ed25519Public {
+        Ed25519Public(self.0.to_public())
+    }
+
+    pub fn bytes(&self) -> Box<[u8]> {
+        self.0.clone().leak_secret().as_ref().into()
+    }
+}
+
+#[wasm_bindgen]
+pub struct Ed25519Signature(chain_crypto::Signature<Box<[u8]>, chain_crypto::Ed25519>);
+
+#[wasm_bindgen]
+pub struct Ed25519Public(chain_crypto::PublicKey<chain_crypto::Ed25519>);
+
+#[wasm_bindgen]
+impl Ed25519Public {
+    pub fn bytes(&self) -> Box<[u8]> {
+        self.0.as_ref().into()
+    }
+
+    pub fn bech32(&self) -> String {
+        use chain_crypto::bech32::Bech32 as _;
+        self.0.to_bech32_str()
+    }
+}
+
+#[wasm_bindgen]
+/// decode a bech32 string to a byte array, disregarding the hrp
+pub fn bech32_decode_to_bytes(input: &str) -> Result<Vec<u8>, JsValue> {
+    bech32::decode(input)
+        .and_then(|(_hrp, words)| bech32::FromBase32::from_base32(&words))
+        .map_err(|err| JsValue::from_str(&format!("{}", err)))
+}
+
+#[wasm_bindgen]
+pub fn symmetric_encrypt(password: &[u8], data: &[u8]) -> Result<Box<[u8]>, JsValue> {
+    symmetric_cipher::encrypt(password, data, rand::rngs::OsRng)
+        .map_err(|e| JsValue::from_str(&format!("encryption failed {}", e)))
+}
+
+#[wasm_bindgen]
+pub fn symmetric_decrypt(password: &[u8], data: &[u8]) -> Result<Box<[u8]>, JsValue> {
+    symmetric_cipher::decrypt(password, data)
+        .map_err(|e| JsValue::from_str(&format!("decryption failed {}", e)))
+}

--- a/keygen/src/utils.rs
+++ b/keygen/src/utils.rs
@@ -1,0 +1,13 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn set_panic_hook() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}

--- a/keygen/tests/web.rs
+++ b/keygen/tests/web.rs
@@ -3,32 +3,10 @@
 #![cfg(target_arch = "wasm32")]
 
 extern crate wasm_bindgen_test;
-use wallet_js::*;
+use keygen::*;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
-
-const BLOCK0: &[u8] = include_bytes!("../../../test-vectors/block0");
-const WALLET_VALUE: u64 = 1000000 + 10000 + 10000 + 1 + 100;
-
-/// test to recover a yoroi style address in the test-vectors block0
-///
-#[wasm_bindgen_test]
-fn yoroi1() {
-    let mut wallet = Wallet::recover("neck bulb teach illegal soul cry monitor claw amount boring provide village rival draft stone", &[]).expect("couldn't recover wallet fully");
-    let settings = wallet.retrieve_funds(BLOCK0).unwrap();
-    assert_eq!(wallet.total_value(), WALLET_VALUE);
-
-    let conversion = wallet.convert(&settings);
-
-    assert_eq!(conversion.num_ignored(), 1);
-    assert_eq!(conversion.total_value_ignored(), 1);
-    assert_eq!(conversion.transactions_len(), 1);
-
-    let _transaction_bytes = conversion
-        .transactions_get(0)
-        .expect("to get the only transaction present in the conversion");
-}
 
 #[wasm_bindgen_test]
 fn gen_key() {
@@ -66,22 +44,4 @@ fn gen_key_from_invalid_seed_fails() {
     const INVALID_SEED_SIZE: usize = 32 + 1;
     let bad_seed = [2u8; INVALID_SEED_SIZE];
     assert!(Ed25519ExtendedPrivate::from_seed(bad_seed.as_ref()).is_err())
-}
-
-#[wasm_bindgen_test]
-fn sign_verify_extended() {
-    let key = Ed25519ExtendedPrivate::generate();
-    let msg = [1, 2, 3, 4u8];
-    let signature = key.sign(&msg);
-
-    assert!(key.public().verify(&signature, &msg));
-}
-
-#[wasm_bindgen_test]
-fn sign_verify() {
-    let key = Ed25519Private::generate();
-    let msg = [1, 2, 3, 4u8];
-    let signature = key.sign(&msg);
-
-    assert!(key.public().verify(&signature, &msg));
 }

--- a/keygen/tests/web.rs
+++ b/keygen/tests/web.rs
@@ -1,0 +1,87 @@
+//! Test suite for the Web and headless browsers.
+
+#![cfg(target_arch = "wasm32")]
+
+extern crate wasm_bindgen_test;
+use wallet_js::*;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+const BLOCK0: &[u8] = include_bytes!("../../../test-vectors/block0");
+const WALLET_VALUE: u64 = 1000000 + 10000 + 10000 + 1 + 100;
+
+/// test to recover a yoroi style address in the test-vectors block0
+///
+#[wasm_bindgen_test]
+fn yoroi1() {
+    let mut wallet = Wallet::recover("neck bulb teach illegal soul cry monitor claw amount boring provide village rival draft stone", &[]).expect("couldn't recover wallet fully");
+    let settings = wallet.retrieve_funds(BLOCK0).unwrap();
+    assert_eq!(wallet.total_value(), WALLET_VALUE);
+
+    let conversion = wallet.convert(&settings);
+
+    assert_eq!(conversion.num_ignored(), 1);
+    assert_eq!(conversion.total_value_ignored(), 1);
+    assert_eq!(conversion.transactions_len(), 1);
+
+    let _transaction_bytes = conversion
+        .transactions_get(0)
+        .expect("to get the only transaction present in the conversion");
+}
+
+#[wasm_bindgen_test]
+fn gen_key() {
+    // just test that the random generator works
+    let _key = Ed25519ExtendedPrivate::generate();
+}
+
+#[wasm_bindgen_test]
+fn encrypt_decrypt() {
+    let data = [1u8; 64 * 2];
+    let password = [1u8, 2, 3, 4];
+    let encrypted = symmetric_encrypt(&password, &data).unwrap();
+    assert_eq!(
+        &symmetric_decrypt(&password, &encrypted).unwrap()[..],
+        &data[..]
+    );
+}
+
+#[wasm_bindgen_test]
+fn gen_key_from_seed() {
+    let seed1 = [1u8; 32];
+    let key1 = Ed25519ExtendedPrivate::from_seed(seed1.as_ref()).unwrap();
+    let key2 = Ed25519ExtendedPrivate::from_seed(seed1.as_ref()).unwrap();
+
+    assert_eq!(key1.bytes(), key2.bytes());
+
+    let seed2 = [2u8; 32];
+    let key3 = Ed25519ExtendedPrivate::from_seed(seed2.as_ref()).unwrap();
+
+    assert_ne!(key3.bytes(), key1.bytes());
+}
+
+#[wasm_bindgen_test]
+fn gen_key_from_invalid_seed_fails() {
+    const INVALID_SEED_SIZE: usize = 32 + 1;
+    let bad_seed = [2u8; INVALID_SEED_SIZE];
+    assert!(Ed25519ExtendedPrivate::from_seed(bad_seed.as_ref()).is_err())
+}
+
+#[wasm_bindgen_test]
+fn sign_verify_extended() {
+    let key = Ed25519ExtendedPrivate::generate();
+    let msg = [1, 2, 3, 4u8];
+    let signature = key.sign(&msg);
+
+    assert!(key.public().verify(&signature, &msg));
+}
+
+#[wasm_bindgen_test]
+fn sign_verify() {
+    let key = Ed25519Private::generate();
+    let msg = [1, 2, 3, 4u8];
+    let signature = key.sign(&msg);
+
+    assert!(key.public().verify(&signature, &msg));
+}

--- a/symmetric-cipher/Cargo.toml
+++ b/symmetric-cipher/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nicolas Di Prima <nicolas@primetype.co.uk>", "Vincent Hanquez <vince
 edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "symmetric-cipher"
-version = "0.5.0-pre7"
+version = "0.5.0-pre8"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet"
-version = "0.5.0-pre7"
+version = "0.5.0-pre8"
 authors = ["Nicolas Di Prima <nicolas@primetype.co.uk>", "Vincent Hanquez <vincent@typed.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
closes #124

TODO:

- [x] Add to CI/CD
Maybe remove the key generation from wallet-js? That stuff is already in `js-chain-libs` anyway.
Probably keygen is a bad name. (Should we call it daedalus-catalyst-interop-js?)