### PR TITLE
Use latest cross and add libdl

### DIFF
--- a/.github/workflows/ci_jni_build.yaml
+++ b/.github/workflows/ci_jni_build.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           use-cross: ${{ matrix.config.cross }}
           command: rustc
-          args: --release --target ${{ matrix.config.target }} -p wallet-jni -- -C lto
+          args: --release --target ${{ matrix.config.target }} -p wallet-jni -- -C lto -C link-args=-ldl
 
       - name: Prepare package
         run: mkdir -p jniLibs/${{ matrix.config.target }}

--- a/.github/workflows/ci_jni_build.yaml
+++ b/.github/workflows/ci_jni_build.yaml
@@ -28,13 +28,6 @@ jobs:
           override: true
           default: true
 
-      - name: Downgrade cross
-        uses: actions-rs/cargo@v1
-        if: ${{ matrix.config.cross }}
-        with:
-          command: install
-          args: --version 0.1.16 cross
-
       - name: Checkout code
         uses: actions/checkout@v1
         with:


### PR DESCRIPTION
For some reason that I don't understand, when cross compiling to arm64 for android, the library is missing a dynamic dependency to `libdl.so`. It only happens with the `release` profile, and I think only with `gcc` as a linker (because that's what `cross` uses, and I'm using clang without cross locally and it doesn't happen).

By adding `-ldl` explicitly as an extra linker flag, it's properly added to the elf header, although I still don't know if that's enough to fix the issue completely as I don't have a way to test on that architecture.

Also, I don't really know why are we downgrading `cross`, seems like a copy-paste leftover.