### PR TITLE
reintroduce decryption function in wallet-js

### DIFF
--- a/bindings/wallet-js/src/lib.rs
+++ b/bindings/wallet-js/src/lib.rs
@@ -396,3 +396,9 @@ impl EncryptingVoteKey {
             .map(Self)
     }
 }
+
+#[wasm_bindgen]
+pub fn symmetric_decrypt(password: &[u8], data: &[u8]) -> Result<Box<[u8]>, JsValue> {
+    symmetric_cipher::decrypt(password, data)
+        .map_err(|e| JsValue::from_str(&format!("decryption failed {}", e)))
+}


### PR DESCRIPTION
as it is needed for the browser platform support, even if it is not used
right now

I removed this when creating the other keygen library, which only needs the encryption, but I included both in case someone wanted to use it for testing. It was wrong to remove it from here, though.