### PR TITLE
update cryptoxide to 0.3.1

### DIFF
--- a/bip39/Cargo.toml
+++ b/bip39/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cryptoxide = "0.1"
+cryptoxide = "0.3.1"
 thiserror = { version = "1.0.13", default-features = false }
 
 [dev-dependencies]

--- a/hdkeygen/Cargo.toml
+++ b/hdkeygen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cryptoxide = "0.2.0"
+cryptoxide = "0.3.1"
 ed25519-bip32 = "^0.3.1"
 bip39 = { path = "../bip39" }
 cbor_event = "^2.1.3"

--- a/symmetric-cipher/Cargo.toml
+++ b/symmetric-cipher/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.5.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cryptoxide = "0.2.0"
+cryptoxide = "0.3.1"
 rand = "0.7.3"
 thiserror = {version = "1.0.13", default-features = false}
 

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cryptoxide = "0.2.0"
+cryptoxide = "0.3.1"
 ed25519-bip32 = "^0.3.1"
 cbor_event = "^2.1.3"
 thiserror = { version = "1.0.13", default-features = false }


### PR DESCRIPTION
This update contains a fix to prevent a compilation error in the
upcoming rustc version.