### PR TITLE
fix invalid account funds tracking

### DIFF
--- a/bindings/wallet-core/src/error.rs
+++ b/bindings/wallet-core/src/error.rs
@@ -61,6 +61,9 @@ pub enum ErrorCode {
     /// vote encryption key is invalid
     /// either because is not valid bech32, or because of the underlying bytes
     InvalidVoteEncryptionKey = 8,
+
+    /// wallet out of funds
+    NotEnoughFunds = 9,
 }
 
 #[derive(Debug)]
@@ -94,6 +97,9 @@ pub enum ErrorKind {
     /// vote encryption key is invalid
     /// either because is not valid bech32, or because of the underlying bytes
     InvalidVoteEncryptionKey,
+
+    /// wallet out of funds
+    NotEnoughFunds,
 }
 
 impl ErrorKind {
@@ -111,6 +117,7 @@ impl ErrorKind {
             Self::SymmetricCipherError => ErrorCode::SymmetricCipherError,
             Self::SymmetricCipherInvalidPassword => ErrorCode::SymmetricCipherInvalidPassword,
             Self::InvalidVoteEncryptionKey => ErrorCode::InvalidVoteEncryptionKey,
+            Self::NotEnoughFunds => ErrorCode::NotEnoughFunds,
         }
     }
 }
@@ -208,6 +215,13 @@ impl Error {
     pub fn invalid_vote_encryption_key() -> Self {
         Self {
             kind: ErrorKind::InvalidVoteEncryptionKey,
+            details: None,
+        }
+    }
+
+    pub fn not_enough_funds() -> Self {
+        Self {
+            kind: ErrorKind::NotEnoughFunds,
             details: None,
         }
     }
@@ -354,6 +368,7 @@ impl Display for ErrorKind {
             Self::SymmetricCipherError => f.write_str("malformed encryption or decryption payload"),
             Self::SymmetricCipherInvalidPassword => f.write_str("invalid decryption password"),
             Self::InvalidVoteEncryptionKey => f.write_str("invalid vote encryption key"),
+            Self::NotEnoughFunds => f.write_str("not enough funds to create transaction"),
         }
     }
 }

--- a/bindings/wallet-core/src/wallet.rs
+++ b/bindings/wallet-core/src/wallet.rs
@@ -345,7 +345,11 @@ impl Wallet {
 
         let value = builder.estimate_fee_with(1, 0);
 
-        let account_tx_builder = self.account.new_transaction(value);
+        let account_tx_builder = self
+            .account
+            .new_transaction(value)
+            .map_err(|_| Error::not_enough_funds())?;
+
         let input = account_tx_builder.input();
         let witness_builder = account_tx_builder.witness_builder();
 

--- a/wallet/src/states.rs
+++ b/wallet/src/states.rs
@@ -36,6 +36,12 @@ pub struct States<K, S> {
     tail: *mut State<K, S>,
 }
 
+impl<K: std::fmt::Debug, S: std::fmt::Debug> std::fmt::Debug for States<K, S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
 impl<K, S> State<K, S> {
     fn new(key: K, state: S, status: Status) -> Self {
         Self {

--- a/wallet/tests/account.rs
+++ b/wallet/tests/account.rs
@@ -119,7 +119,7 @@ fn cast_vote() {
 
     let value = builder.estimate_fee_with(1, 0);
 
-    let account_tx_builder = account.new_transaction(value);
+    let account_tx_builder = account.new_transaction(value).unwrap();
     let input = account_tx_builder.input();
     let witness_builder = account_tx_builder.witness_builder();
 

--- a/wallet/tests/utils/mod.rs
+++ b/wallet/tests/utils/mod.rs
@@ -8,7 +8,7 @@ use wallet::Settings;
 
 pub struct State {
     block0: Block,
-    ledger: Ledger,
+    pub ledger: Ledger,
 }
 
 impl State {


### PR DESCRIPTION
also add error when there not enough funds for creating the transaction

I realized when working on #149 that the funds tracking for the account wallet was incorrect, we were setting the available funds to the funds required for the transaction (after creating the transaction).

It's not a huge issue because we were not using the value for validation anyway, but with this PR we now throws an error if there are not enough funds for the transaction, besides fixing the logic.