### PR TITLE
Add cordova test setup script

### DIFF
--- a/.github/workflows/ci_integration.yaml
+++ b/.github/workflows/ci_integration.yaml
@@ -189,11 +189,36 @@ jobs:
           command: install
           args: cross
 
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: rustc
+          args: --target aarch64-linux-android -p wallet-jni -- -C link-args=-ldl
+
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: rustc
+          args: --target armv7-linux-androideabi -p wallet-jni -- -C link-args=-ldl
+
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: rustc
+          args: --target i686-linux-android -p wallet-jni -- -C link-args=-ldl
+
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: rustc
+          args: --target x86_64 -p wallet-jni -- -C link-args=-ldl
+
       - name: build test app
         run: |
           python3 bindings/wallet-cordova/tests/setup.py \
             --directory test_app \
             --platform android \
+            --no-cargo-build \
             -- setup
         env:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}

--- a/.github/workflows/ci_integration.yaml
+++ b/.github/workflows/ci_integration.yaml
@@ -190,7 +190,8 @@ jobs:
 
       - name: build test app
         run: |
-          python3 bindings/wallet-cordova/tests/prepare_test.py \
+          python3 bindings/wallet-cordova/tests/setup.py \
+            --directory test_app \
             --platform android \
             -- setup
         env:

--- a/.github/workflows/ci_integration.yaml
+++ b/.github/workflows/ci_integration.yaml
@@ -156,13 +156,13 @@ jobs:
           default: true
 
       - name: build wasm for electron
-        run: python3 ./bindings/wallet-cordova/build_wasm.py
+        run: python3 bindings/wallet-cordova/build_wasm.py
 
       - name: build jni libs
-        run: python3 ./bindings/wallet-cordova/build_jni.py
+        run: python3 bindings/wallet-cordova/build_jni.py
 
       - name: build ios libs
-        run: python3 ./bindings/wallet-cordova/build_ios.py
+        run: python3 bindings/wallet-cordova/build_ios.py
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
@@ -196,7 +196,7 @@ jobs:
 
       - name: build test app
         run: |
-          python3 ./bindings/wallet-cordova/tests/prepare_test.py \
+          python3 bindings/wallet-cordova/tests/prepare_test.py \
             --platform android \
             -- setup
         env:

--- a/.github/workflows/ci_integration.yaml
+++ b/.github/workflows/ci_integration.yaml
@@ -65,3 +65,63 @@ jobs:
           use-cross: ${{ matrix.config.cross }}
           command: rustc
           args: --release --target ${{ matrix.config.target }} -p jormungandrwallet -- -C lto
+
+
+  build_cordova_app:
+    name: Check cordova plugin 
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.config.toolchain }}
+          target: ${{ matrix.config.target }}
+          override: true
+          default: true
+
+      - name: build wasm for electron 
+        run: python3 ./bindings/wallet-cordova/build_wasm.py 
+
+      - name: build jni libs
+        run: python3 ./bindings/wallet-cordova/build_jni.py
+
+      - name: build ios libs
+        run: python3 ./bindings/wallet-cordova/build_ios.py
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Setup Android NDK
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+          add-to-path: false
+      - run: ./build.sh
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+
+      - name: setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Use oxr463/setup-cordova
+        uses: oxr463/setup-cordova@0.0.2
+
+      - name: build test app
+        run: |  
+          python3 ./bindings/wallet-cordova/tests/prepare_test.py \
+            --platform android \
+            -- setup
+

--- a/.github/workflows/ci_integration.yaml
+++ b/.github/workflows/ci_integration.yaml
@@ -186,7 +186,8 @@ jobs:
 
       - uses: actions-rs/cargo@v1
         with:
-          use-cross: true
+          command: install
+          args: cross
 
       - name: build test app
         run: |

--- a/.github/workflows/ci_integration.yaml
+++ b/.github/workflows/ci_integration.yaml
@@ -206,7 +206,7 @@ jobs:
         with:
           use-cross: true
           command: rustc
-          args: --target x86_64 -p wallet-jni -- -C link-args=-ldl
+          args: --target x86_64-linux-android -p wallet-jni -- -C link-args=-ldl
 
       - name: build test app
         run: |

--- a/.github/workflows/ci_integration.yaml
+++ b/.github/workflows/ci_integration.yaml
@@ -155,6 +155,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          target: x86_64-apple-darwin
           override: true
           default: true
 
@@ -183,11 +184,6 @@ jobs:
 
       - name: Setup cordova
         run: sudo npm install -g cordova
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cross
 
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci_integration.yaml
+++ b/.github/workflows/ci_integration.yaml
@@ -15,29 +15,114 @@ jobs:
       matrix:
         config:
           # Linux
-          - { os: ubuntu-latest, cross: false, toolchain: stable, target: x86_64-unknown-linux-gnu }
-          - { os: ubuntu-latest, cross: true, toolchain: stable, target: aarch64-unknown-linux-gnu }
-          - { os: ubuntu-latest, cross: true, toolchain: stable, target: arm-unknown-linux-gnueabi }
-          - { os: ubuntu-latest, cross: true, toolchain: stable, target: armv7-unknown-linux-gnueabihf }
-          - { os: ubuntu-latest, cross: true, toolchain: stable, target: mips64el-unknown-linux-gnuabi64 }
-          - { os: ubuntu-latest, cross: true, toolchain: stable, target: powerpc64le-unknown-linux-gnu }
-          - { os: ubuntu-latest, cross: true, toolchain: stable, target: x86_64-unknown-linux-musl }
+          - {
+              os: ubuntu-latest,
+              cross: false,
+              toolchain: stable,
+              target: x86_64-unknown-linux-gnu,
+            }
+          - {
+              os: ubuntu-latest,
+              cross: true,
+              toolchain: stable,
+              target: aarch64-unknown-linux-gnu,
+            }
+          - {
+              os: ubuntu-latest,
+              cross: true,
+              toolchain: stable,
+              target: arm-unknown-linux-gnueabi,
+            }
+          - {
+              os: ubuntu-latest,
+              cross: true,
+              toolchain: stable,
+              target: armv7-unknown-linux-gnueabihf,
+            }
+          - {
+              os: ubuntu-latest,
+              cross: true,
+              toolchain: stable,
+              target: mips64el-unknown-linux-gnuabi64,
+            }
+          - {
+              os: ubuntu-latest,
+              cross: true,
+              toolchain: stable,
+              target: powerpc64le-unknown-linux-gnu,
+            }
+          - {
+              os: ubuntu-latest,
+              cross: true,
+              toolchain: stable,
+              target: x86_64-unknown-linux-musl,
+            }
           # Android
-          - { os: ubuntu-latest, cross: true, toolchain: stable, target: aarch64-linux-android }
-          - { os: ubuntu-latest, cross: true, toolchain: stable, target: arm-linux-androideabi }
-          - { os: ubuntu-latest, cross: true, toolchain: stable, target: armv7-linux-androideabi }
-          - { os: ubuntu-latest, cross: true, toolchain: stable, target: i686-linux-android }
-          - { os: ubuntu-latest, cross: true, toolchain: stable, target: x86_64-linux-android }
+          - {
+              os: ubuntu-latest,
+              cross: true,
+              toolchain: stable,
+              target: aarch64-linux-android,
+            }
+          - {
+              os: ubuntu-latest,
+              cross: true,
+              toolchain: stable,
+              target: arm-linux-androideabi,
+            }
+          - {
+              os: ubuntu-latest,
+              cross: true,
+              toolchain: stable,
+              target: armv7-linux-androideabi,
+            }
+          - {
+              os: ubuntu-latest,
+              cross: true,
+              toolchain: stable,
+              target: i686-linux-android,
+            }
+          - {
+              os: ubuntu-latest,
+              cross: true,
+              toolchain: stable,
+              target: x86_64-linux-android,
+            }
           # tumbv7neon not yet supported
           # - { os: ubuntu-latest, cross: true, toolchain: stable, target: thumbv7neon-linux-androideabi }
           # Macos
-          - { os: macos-latest, cross: false, toolchain: stable, target: x86_64-apple-darwin }
+          - {
+              os: macos-latest,
+              cross: false,
+              toolchain: stable,
+              target: x86_64-apple-darwin,
+            }
           # iOS
-          - { os: macos-latest, cross: false, toolchain: stable, target: aarch64-apple-ios }
-          - { os: macos-latest, cross: false, toolchain: stable, target: x86_64-apple-ios }
+          - {
+              os: macos-latest,
+              cross: false,
+              toolchain: stable,
+              target: aarch64-apple-ios,
+            }
+          - {
+              os: macos-latest,
+              cross: false,
+              toolchain: stable,
+              target: x86_64-apple-ios,
+            }
           # Windows
-          - { os: windows-latest, cross: false, toolchain: stable-x86_64-pc-windows-gnu, target: x86_64-pc-windows-gnu }
-          - { os: windows-latest, cross: false, toolchain: stable-x86_64-pc-windows-msvc, target: x86_64-pc-windows-msvc }
+          - {
+              os: windows-latest,
+              cross: false,
+              toolchain: stable-x86_64-pc-windows-gnu,
+              target: x86_64-pc-windows-gnu,
+            }
+          - {
+              os: windows-latest,
+              cross: false,
+              toolchain: stable-x86_64-pc-windows-msvc,
+              target: x86_64-pc-windows-msvc,
+            }
 
     steps:
       - uses: actions-rs/toolchain@v1
@@ -46,13 +131,6 @@ jobs:
           target: ${{ matrix.config.target }}
           override: true
           default: true
-
-      - name: Downgrade cross
-        uses: actions-rs/cargo@v1
-        if: ${{ matrix.config.cross }}
-        with:
-          command: install
-          args: --version 0.1.16 cross
 
       - name: Checkout code
         uses: actions/checkout@v1
@@ -66,21 +144,19 @@ jobs:
           command: rustc
           args: --release --target ${{ matrix.config.target }} -p jormungandrwallet -- -C lto
 
-
   build_cordova_app:
-    name: Check cordova plugin 
+    name: Check cordova plugin
     runs-on: macos-latest
 
     steps:
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.config.toolchain }}
-          target: ${{ matrix.config.target }}
+          toolchain: stable
           override: true
           default: true
 
-      - name: build wasm for electron 
-        run: python3 ./bindings/wallet-cordova/build_wasm.py 
+      - name: build wasm for electron
+        run: python3 ./bindings/wallet-cordova/build_wasm.py
 
       - name: build jni libs
         run: python3 ./bindings/wallet-cordova/build_jni.py
@@ -97,14 +173,9 @@ jobs:
         uses: android-actions/setup-android@v2
 
       - name: Setup Android NDK
-      - uses: nttld/setup-ndk@v1
-        id: setup-ndk
+        uses: nttld/setup-ndk@v1
         with:
           ndk-version: r21e
-          add-to-path: false
-      - run: ./build.sh
-        env:
-          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
 
       - name: setup node
         uses: actions/setup-node@v1
@@ -119,9 +190,14 @@ jobs:
       - name: Use oxr463/setup-cordova
         uses: oxr463/setup-cordova@0.0.2
 
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+
       - name: build test app
-        run: |  
+        run: |
           python3 ./bindings/wallet-cordova/tests/prepare_test.py \
             --platform android \
             -- setup
-
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}

--- a/.github/workflows/ci_integration.yaml
+++ b/.github/workflows/ci_integration.yaml
@@ -149,20 +149,14 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
           default: true
-
-      - name: build wasm for electron
-        run: python3 bindings/wallet-cordova/build_wasm.py
-
-      - name: build jni libs
-        run: python3 bindings/wallet-cordova/build_jni.py
-
-      - name: build ios libs
-        run: python3 bindings/wallet-cordova/build_ios.py
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1

--- a/.github/workflows/ci_integration.yaml
+++ b/.github/workflows/ci_integration.yaml
@@ -168,6 +168,7 @@ jobs:
 
       - name: Setup Android NDK
         uses: nttld/setup-ndk@v1
+        id: setup-ndk
         with:
           ndk-version: r21e
 

--- a/.github/workflows/ci_integration.yaml
+++ b/.github/workflows/ci_integration.yaml
@@ -181,8 +181,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Use oxr463/setup-cordova
-        uses: oxr463/setup-cordova@0.0.2
+      - name: Setup cordova
+        run: sudo npm install -g cordova
 
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci_integration.yaml
+++ b/.github/workflows/ci_integration.yaml
@@ -146,7 +146,7 @@ jobs:
 
   build_cordova_app:
     name: Check cordova plugin
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -155,7 +155,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: x86_64-apple-darwin
           override: true
           default: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+**/__pycache__

--- a/bindings/wallet-cordova/build_ios.py
+++ b/bindings/wallet-cordova/build_ios.py
@@ -16,15 +16,32 @@ targets = {
     "aarch64-apple-ios": "arm64",
 }
 
-def run():
+
+def run(release=True):
     lipo_args = ["lipo", "-create", "-output", "./src/ios/" + libname]
 
     for rust_target, apple_target in targets.items():
-        out = subprocess.run(["cargo", "rustc", "--release", "--target", rust_target, "-p" "jormungandrwallet", "--", "-C", "lto"])
+        arguments = [
+            "cross",
+            "rustc",
+            "--target",
+            rust_target,
+            "-p",
+            "jormungandrwallet",
+        ]
+
+        if release:
+            arguments = arguments + ["--release", "--", "-C", "lto"]
+
+        out = subprocess.run(arguments)
         if out.returncode != 0:
             print("couldn't build for target: ", rust_target)
             sys.exit(1)
-        lipo_args += ["-arch", apple_target, str(root_directory / rust_target / "release" / libname)]
+        lipo_args += [
+            "-arch",
+            apple_target,
+            str(root_directory / rust_target / "release" / libname),
+        ]
 
     out = subprocess.run(lipo_args)
     if out.returncode != 0:

--- a/bindings/wallet-cordova/build_jni.py
+++ b/bindings/wallet-cordova/build_jni.py
@@ -19,6 +19,15 @@ targets = {
 }
 
 
+def copy_libs():
+    for rust_target, android_target in targets.items():
+        dst = script_directory / copy_to / android_target
+        dst.mkdir(parents=True, exist_ok=True)
+
+        src = root_directory / rust_target / "release" / libname
+        shutil.copy(src, dst)
+
+
 def run(release=True):
     for rust_target, android_target in targets.items():
         arguments = [
@@ -39,12 +48,7 @@ def run(release=True):
             print("couldn't build for target: ", rust_target)
             sys.exit(1)
 
-        dst = script_directory / copy_to / android_target
-        dst.mkdir(parents=True, exist_ok=True)
-
-        src = root_directory / rust_target / "release" / libname
-        shutil.copy(src, dst)
-
+    copy_libs()
     copy_definitions()
 
 

--- a/bindings/wallet-cordova/build_jni.py
+++ b/bindings/wallet-cordova/build_jni.py
@@ -19,12 +19,14 @@ targets = {
 }
 
 
-def copy_libs():
+def copy_libs(release=True):
     for rust_target, android_target in targets.items():
         dst = script_directory / copy_to / android_target
         dst.mkdir(parents=True, exist_ok=True)
 
-        src = root_directory / rust_target / "release" / libname
+        debug_or_release = "release" if release else "debug"
+
+        src = root_directory / rust_target / debug_or_release / libname
         shutil.copy(src, dst)
 
 
@@ -48,7 +50,7 @@ def run(release=True):
             print("couldn't build for target: ", rust_target)
             sys.exit(1)
 
-    copy_libs()
+    copy_libs(release)
     copy_definitions()
 
 

--- a/bindings/wallet-cordova/build_jni.py
+++ b/bindings/wallet-cordova/build_jni.py
@@ -19,16 +19,27 @@ targets = {
 }
 
 
-def run():
+def run(release=True):
     for rust_target, android_target in targets.items():
-        out = subprocess.run(["cross", "rustc", "--release", "--target",
-                              rust_target, "-p" "wallet-jni", "--", "-C", "lto"])
+        arguments = [
+            "cross",
+            "rustc",
+            "--target",
+            rust_target,
+            "-p",
+            "wallet-jni",
+        ]
+
+        if release:
+            arguments = arguments + ["--release", "--", "-C", "lto"]
+
+        out = subprocess.run(arguments)
 
         if out.returncode != 0:
             print("couldn't build for target: ", rust_target)
             sys.exit(1)
 
-        dst = (script_directory / copy_to / android_target)
+        dst = script_directory / copy_to / android_target
         dst.mkdir(parents=True, exist_ok=True)
 
         src = root_directory / rust_target / "release" / libname

--- a/bindings/wallet-cordova/tests/setup.py
+++ b/bindings/wallet-cordova/tests/setup.py
@@ -85,7 +85,7 @@ def install_main_plugin(
         if cargo_build:
             build_jni(release=False)
         else:
-            copy_jni_libs()
+            copy_jni_libs(release=False)
             copy_jni_definitions()
 
     if ios and cargo_build:

--- a/bindings/wallet-cordova/tests/setup.py
+++ b/bindings/wallet-cordova/tests/setup.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+# cordova create hello com.example.hello HelloWorld
+# cd hello
+# cordova platform add android
+# cordova plugin add cordova-plugin-test-framework
+# cordova plugin add this-plugin-path
+# cordova plugin add path-to-wallet-cordova/tests
+# sed 's/<content src="index.html" \/>/<content src="cdvtests\/index.html" \/>/' config.xml -i
+# cordova build
+# cordova run android
+
+import subprocess
+
+from pathlib import Path
+import subprocess
+import sys
+import shutil
+import argparse
+import os
+import re
+
+sys.path.append(str(Path(__file__).parent.parent))
+from build_jni import run as build_jni
+from build_ios import run as build_ios
+
+root_directory = Path("../../../")
+
+
+def sed(original: str, replacement: str, file: Path):
+    # TODO: this may have some problems, but I'm also not sure if I want to use
+    # `sed`, mostly for Windows compatibility
+    with open(file, "r") as config:
+        lines = config.readlines()
+
+    with open(file, "w") as config:
+        for line in lines:
+            config.write(re.sub(original, replacement, line))
+
+
+def create_hello_world(build_dir: Path):
+    os.makedirs(build_dir, exist_ok=True)
+
+    subprocess.call(
+        ["cordova", "create", "hello", "com.example.hello", "HelloWorld"],
+        cwd=build_dir,
+    )
+
+
+def install_test_framework(app_dir: Path):
+    subprocess.call(
+        ["cordova", "plugin", "add", "cordova-plugin-test-framework"], cwd=app_dir
+    )
+
+    sed(
+        '<content src="index.html" />',
+        '<content src="cdvtests/index.html" />',
+        app_dir / "config.xml",
+    )
+
+
+def install_platforms(app_dir: Path, android=True, ios=True):
+    if android:
+        subprocess.call(["cordova", "platform", "add", "android"], cwd=app_dir)
+
+    if ios:
+        subprocess.call(["cordova", "platform", "add", "ios"], cwd=app_dir)
+
+
+def install_main_plugin(app_dir: Path, reinstall=True, android=False, ios=False):
+    plugin_path = Path(__file__).parent.parent
+
+    print(f"plugin_path: {plugin_path}")
+
+    if reinstall:
+        subprocess.call(
+            ["cordova", "plugin", "rm", "wallet-cordova-plugin"], cwd=app_dir
+        )
+
+    if android:
+        build_jni(release=False)
+
+    if ios:
+        build_ios()
+
+    subprocess.call(["cordova", "plugin", "add", str(plugin_path)], cwd=app_dir)
+
+
+def install_test_plugin(app_dir: Path, reinstall=True):
+    tests_path = Path(__file__).parent
+
+    print(f"tests_path: {tests_path}")
+
+    subprocess.call(["npm", "run", "build"], cwd=tests_path)
+
+    if reinstall:
+        subprocess.call(
+            ["cordova", "plugin", "rm", "wallet-cordova-plugin-tests"], cwd=app_dir
+        )
+
+    subprocess.call(["cordova", "plugin", "add", str(tests_path)], cwd=app_dir)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Create test harness")
+
+    platform_choices = ["android", "ios"]
+
+    parser.add_argument(
+        "--platform", required=True, nargs="+", choices=platform_choices
+    )
+    parser.add_argument("command", choices=["setup", "plugin", "tests"])
+    parser.add_argument("-d", "--directory", type=Path)
+    parser.add_argument("-r", "--run", choices=platform_choices)
+
+    args = parser.parse_args()
+
+    android = "android" in args.platform
+    ios = "ios" in args.platform
+
+    build_dir = args.directory
+
+    app_dir = build_dir / "hello"
+
+    if args.command == "setup":
+        create_hello_world(build_dir)
+        install_platforms(app_dir, android=android, ios=ios)
+        install_test_framework(app_dir)
+        install_main_plugin(app_dir, reinstall=False, android=android, ios=ios)
+        install_test_plugin(app_dir, reinstall=False)
+
+    if args.command == "plugin":
+        install_main_plugin(app_dir, reinstall=True, android=android, ios=ios)
+
+    if args.command == "tests":
+        install_test_plugin(app_dir, reinstall=True)
+
+    subprocess.call(["cordova", "build"], cwd=app_dir)
+    if args.run:
+        subprocess.call(["cordova", "run", args.run], cwd=app_dir)

--- a/bindings/wallet-cordova/tests/setup.py
+++ b/bindings/wallet-cordova/tests/setup.py
@@ -99,6 +99,7 @@ def install_test_plugin(app_dir: Path, reinstall=True):
 
     print(f"tests_path: {tests_path}")
 
+    subprocess.call(["npm", "install"], cwd=tests_path)
     subprocess.call(["npm", "run", "build"], cwd=tests_path)
 
     if reinstall:

--- a/bindings/wallet-cordova/tests/setup.py
+++ b/bindings/wallet-cordova/tests/setup.py
@@ -121,12 +121,9 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--directory", type=Path)
     parser.add_argument("-r", "--run", choices=platform_choices)
 
-    parser.add_argument(
-        "--cargo-build",
-        default=True,
-        action=argparse.BooleanOptionalAction,
-        dest="cargo_build",
-    )
+    parser.add_argument("--cargo-build", dest="cargo_build", action="store_true")
+    parser.add_argument("--no-cargo-build", dest="cargo_build", action="store_false")
+    parser.set_defaults(feature=True)
 
     args = parser.parse_args()
 

--- a/bindings/wallet-cordova/tests/setup.py
+++ b/bindings/wallet-cordova/tests/setup.py
@@ -43,14 +43,14 @@ def sed(original: str, replacement: str, file: Path):
 def create_hello_world(build_dir: Path):
     os.makedirs(build_dir, exist_ok=True)
 
-    subprocess.call(
+    subprocess.check_call(
         ["cordova", "create", "hello", "com.example.hello", "HelloWorld"],
         cwd=build_dir,
     )
 
 
 def install_test_framework(app_dir: Path):
-    subprocess.call(
+    subprocess.check_call(
         ["cordova", "plugin", "add", "cordova-plugin-test-framework"], cwd=app_dir
     )
 
@@ -63,10 +63,10 @@ def install_test_framework(app_dir: Path):
 
 def install_platforms(app_dir: Path, android=True, ios=True):
     if android:
-        subprocess.call(["cordova", "platform", "add", "android"], cwd=app_dir)
+        subprocess.check_call(["cordova", "platform", "add", "android"], cwd=app_dir)
 
     if ios:
-        subprocess.call(["cordova", "platform", "add", "ios"], cwd=app_dir)
+        subprocess.check_call(["cordova", "platform", "add", "ios"], cwd=app_dir)
 
 
 def install_main_plugin(
@@ -77,7 +77,7 @@ def install_main_plugin(
     print(f"plugin_path: {plugin_path}")
 
     if reinstall:
-        subprocess.call(
+        subprocess.check_call(
             ["cordova", "plugin", "rm", "wallet-cordova-plugin"], cwd=app_dir
         )
 
@@ -91,7 +91,7 @@ def install_main_plugin(
     if ios and cargo_build:
         build_ios()
 
-    subprocess.call(["cordova", "plugin", "add", str(plugin_path)], cwd=app_dir)
+    subprocess.check_call(["cordova", "plugin", "add", str(plugin_path)], cwd=app_dir)
 
 
 def install_test_plugin(app_dir: Path, reinstall=True):
@@ -99,15 +99,15 @@ def install_test_plugin(app_dir: Path, reinstall=True):
 
     print(f"tests_path: {tests_path}")
 
-    subprocess.call(["npm", "install"], cwd=tests_path)
-    subprocess.call(["npm", "run", "build"], cwd=tests_path)
+    subprocess.check_call(["npm", "install"], cwd=tests_path)
+    subprocess.check_call(["npm", "run", "build"], cwd=tests_path)
 
     if reinstall:
-        subprocess.call(
+        subprocess.check_call(
             ["cordova", "plugin", "rm", "wallet-cordova-plugin-tests"], cwd=app_dir
         )
 
-    subprocess.call(["cordova", "plugin", "add", str(tests_path)], cwd=app_dir)
+    subprocess.check_call(["cordova", "plugin", "add", str(tests_path)], cwd=app_dir)
 
 
 if __name__ == "__main__":
@@ -154,6 +154,6 @@ if __name__ == "__main__":
     if args.command == "tests":
         install_test_plugin(app_dir, reinstall=True)
 
-    subprocess.call(["cordova", "build"], cwd=app_dir)
+    subprocess.check_call(["cordova", "build"], cwd=app_dir)
     if args.run:
-        subprocess.call(["cordova", "run", args.run], cwd=app_dir)
+        subprocess.check_call(["cordova", "run", args.run], cwd=app_dir)

--- a/bindings/wallet-cordova/tests/setup.py
+++ b/bindings/wallet-cordova/tests/setup.py
@@ -1,15 +1,5 @@
 #!/usr/bin/env python
 
-# cordova create hello com.example.hello HelloWorld
-# cd hello
-# cordova platform add android
-# cordova plugin add cordova-plugin-test-framework
-# cordova plugin add this-plugin-path
-# cordova plugin add path-to-wallet-cordova/tests
-# sed 's/<content src="index.html" \/>/<content src="cdvtests\/index.html" \/>/' config.xml -i
-# cordova build
-# cordova run android
-
 import subprocess
 
 from pathlib import Path
@@ -20,6 +10,8 @@ import argparse
 import os
 import re
 
+# TODO: probably should move this to the parent directory
+# this makes it possible to include the python scripts in the directory above
 sys.path.append(str(Path(__file__).parent.parent))
 from build_jni import run as build_jni
 from build_jni import copy_libs as copy_jni_libs


### PR DESCRIPTION
this closes #155 (when it's finished)

But it does more than that.

Basically the goal is to remove `TESTING.md` and replace it with something more automated, especially for using it in an edit-compile-cycle. The script itself still needs some docs.

Quoting myself from the first commit message:

>  Running the tests right now involves multiple steps, and not only because of
>     cordova. These steps are only documented in TESTING.md, but this is
>     unwelcoming and error prone.
>     
>     This script tries to automatize that process, in a similar way to
>     cordova-paramedic, but with some differences:
>     
>     - This doesn't force you to use a temporary directory and setup
>     everything each time. This matters because you can save time when
>     making changes by just re-installing the plugin or the tests plugin.
>     
>     - This doesn't do the whole thing that cordova paramedic does for
>       collecting the test results, although that's not working for me with
>       paramedic anyway.
>     
>     - This, of course, does the things that paramedic wouldn't be able to
>       do, that is:
>     
>       - Build the native libraries.
>       - Copy them to the right place.
>       - Run the tests bundling command.
>     
>       This is important because it's easy to forget to do a step in an
>       edit-compile-run cycle.

Something I started to thing after actually writing this, is that maybe using some Makefile-like tool would be better, but I'd like to avoid Makefiles and I think python is fine anyway.