### PR TITLE
Small fixes in wallet bindings API and code

### DIFF
--- a/bindings/wallet-c/src/lib.rs
+++ b/bindings/wallet-c/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod settings;
-pub use chain_impl_mockchain::vote::PayloadType as PayloadTypeRust;
 use std::{
     ffi::{CStr, CString},
     os::raw::c_char,
@@ -41,20 +40,6 @@ pub type ProposalPtr = *mut Proposal;
 pub type FragmentPtr = *mut Fragment;
 pub type ErrorPtr = *mut Error;
 pub type EncryptingVoteKeyPtr = *mut EncryptingVoteKey;
-
-/// Payload type for voting
-#[repr(u8)]
-pub enum PayloadType {
-    Public = 1,
-}
-
-impl From<PayloadType> for PayloadTypeRust {
-    fn from(c_enum: PayloadType) -> Self {
-        match c_enum {
-            PayloadType::Public => PayloadTypeRust::Public,
-        }
-    }
-}
 
 /// retrieve a wallet from the given mnemonics, password and protocol magic
 ///

--- a/bindings/wallet-js/src/lib.rs
+++ b/bindings/wallet-js/src/lib.rs
@@ -38,11 +38,6 @@ pub struct VotePlanId([u8; wallet_core::VOTE_PLAN_ID_LENGTH]);
 #[wasm_bindgen]
 pub struct Options(wallet_core::Options);
 
-#[wasm_bindgen]
-pub enum PayloadType {
-    Public,
-}
-
 impl_secret_key!(
     Ed25519ExtendedPrivate,
     chain_crypto::Ed25519Extended,

--- a/wallet/src/scheme/freeutxo.rs
+++ b/wallet/src/scheme/freeutxo.rs
@@ -77,7 +77,7 @@ impl Wallet {
 
     fn check(&self, pk: &PublicKey<Ed25519>) -> Option<SecretKey<Ed25519Extended>> {
         // FIXME: O(n)?
-        self.keys.iter().cloned().find(|k| &k.to_public() == pk)
+        self.keys.iter().find(|&k| &k.to_public() == pk).cloned()
     }
 
     pub fn check_fragment(&mut self, fragment_id: &FragmentId, fragment: &Fragment) -> bool {


### PR DESCRIPTION
Removed `PayloadType` enum from wallet-js and wallet-c, as it is no
longer used.
Reduce cloning in UTxO wallet initialization.