### PR TITLE
cordova-ios remove stdint-uint import

### DIFF
--- a/bindings/wallet-cordova/src/ios/WalletPlugin.m
+++ b/bindings/wallet-cordova/src/ios/WalletPlugin.m
@@ -1,6 +1,4 @@
 #import "WalletPlugin.h"
-#include <bits/stdint-uintn.h>
-
 #import <Foundation/Foundation.h>
 
 #include <memory.h>


### PR DESCRIPTION
which seems like my editor introduced by itself

I should have removed this with #175 