### PR TITLE
0.7.0-pre4: update manifest version numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "991984e3fd003e7ba02eb724f87a0f997b78677c46c0e91f8424ad7394c9886a"
+dependencies = [
+ "getrandom 0.2.3",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +493,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "hdkeygen"
 version = "0.2.0"
 dependencies = [
@@ -651,6 +680,12 @@ checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -1087,6 +1122,7 @@ dependencies = [
  "chain-time",
  "cryptoxide",
  "ed25519-bip32",
+ "hashlink",
  "hdkeygen",
  "hex",
  "imhamt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jormungandrwallet"
-version = "0.7.0-pre3"
+version = "0.7.0-pre4"
 dependencies = [
  "bip39",
  "chain-addr",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-core"
-version = "0.7.0-pre3"
+version = "0.7.0-pre4"
 dependencies = [
  "bech32",
  "bip39",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-jni"
-version = "0.7.0-pre3"
+version = "0.7.0-pre4"
 dependencies = [
  "chain-impl-mockchain",
  "jni",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-js"
-version = "0.7.0-pre3"
+version = "0.7.0-pre4"
 dependencies = [
  "bech32",
  "chain-crypto",

--- a/bindings/wallet-c/Cargo.toml
+++ b/bindings/wallet-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jormungandrwallet"
-version = "0.7.0-pre3"
+version = "0.7.0-pre4"
 authors = ["Nicolas Di Prima <nicolas@primetype.co.uk>", "Vincent Hanquez <vincent@typed.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/bindings/wallet-cordova/package.json
+++ b/bindings/wallet-cordova/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wallet-cordova-plugin",
-  "version": "0.7.0-pre3",
+  "version": "0.7.0-pre4",
   "description": "Jormungandr wallet Cordova Plugin",
   "cordova": {
     "id": "wallet-cordova-plugin",

--- a/bindings/wallet-cordova/tests/plugin.xml
+++ b/bindings/wallet-cordova/tests/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="wallet-cordova-plugin-tests"
-    version="0.7.0-pre3">
+    version="0.7.0-pre4">
     <name>Wallet cordova plugin tests</name>
     <license>Apache 2.0 OR MIT</license>
 

--- a/bindings/wallet-core/Cargo.toml
+++ b/bindings/wallet-core/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nicolas Di Prima <nicolas@primetype.co.uk>", "Vincent Hanquez <vince
 edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "wallet-core"
-version = "0.7.0-pre3"
+version = "0.7.0-pre4"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/bindings/wallet-jni/Cargo.toml
+++ b/bindings/wallet-jni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet-jni"
-version = "0.7.0-pre3"
+version = "0.7.0-pre4"
 authors = ["Daniel Sanchez Quiros <daniel.sanchez@iohk.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/bindings/wallet-js/Cargo.toml
+++ b/bindings/wallet-js/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "wallet-js"
 repository = "https://github.com/input-output-hk/chain-wallet-libs"
-version = "0.7.0-pre3"
+version = "0.7.0-pre4"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
This is port of the commits https://github.com/input-output-hk/chain-wallet-libs/commit/09b38e6689271094c99657037dc4c3ea92d79e88 and https://github.com/input-output-hk/chain-wallet-libs/commit/ad4ddaacd191959be8594e59d4d7f58ce4d41fde from the https://github.com/input-output-hk/chain-wallet-libs/commits/catalyst-fund6 branch