### PR TITLE
fix `mismatched types` issue in chain_code method

### DIFF
--- a/hdkeygen/src/key.rs
+++ b/hdkeygen/src/key.rs
@@ -95,7 +95,8 @@ impl<P> Key<XPrv, P> {
     /// get key's chain code
     #[inline]
     pub fn chain_code(&self) -> [u8; 32] {
-        self.key.chain_code()
+        #[allow(clippy::clone_on_copy)]
+        self.key.chain_code().clone()
     }
 
     /// derive the private key against the given derivation index and scheme


### PR DESCRIPTION
I don't understand why it happen but on my machine when building chain-wallet-lib as dependency of vit-testing gives me error (see https://github.com/input-output-hk/vit-testing/pull/167)
```
{}\.cargo\git\checkouts\chain-wallet-libs-d32604dd2d0b1f54\95623d5\hdkeygen\src\key.rs:98:9
   |
97 |     pub fn chain_code(&self) -> [u8; 32] {
   |                                 -------- expected `[u8; 32]` because of return type
98 |         self.key.chain_code()
   |         ^^^^^^^^^^^^^^^^^^^^^ expected array `[u8; 32]`, found `&[u8; 32]`
   |
help: consider dereferencing the borrow
   |
98 |         *self.key.chain_code()
   |         +
```

However if i built it separately:

```
cargo build --features builtin-bindgen
```

Works ok. 