### PR TITLE
update cryptoxide to latest master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
 name = "bip39"
 version = "0.1.0"
 dependencies = [
- "cryptoxide 0.4.2 (git+https://github.com/typed-io/cryptoxide.git?branch=master)",
+ "cryptoxide",
  "hex",
  "quickcheck",
  "quickcheck_macros",
@@ -179,7 +179,7 @@ source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#16
 dependencies = [
  "cbor_event",
  "chain-ser",
- "cryptoxide 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cryptoxide",
  "ed25519-bip32",
 ]
 
@@ -238,7 +238,7 @@ dependencies = [
  "bech32 0.8.1",
  "chain-core",
  "chain-crypto",
- "cryptoxide 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cryptoxide",
 ]
 
 [[package]]
@@ -255,7 +255,7 @@ version = "0.1.0"
 source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#1626503c539d31925fcd99c2683edc4f73ee15a6"
 dependencies = [
  "bech32 0.8.1",
- "cryptoxide 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cryptoxide",
  "curve25519-dalek-ng",
  "ed25519-bip32",
  "ed25519-dalek",
@@ -279,7 +279,7 @@ dependencies = [
  "chain-ser",
  "chain-time",
  "chain-vote",
- "cryptoxide 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cryptoxide",
  "hex",
  "imhamt",
  "rand 0.8.4",
@@ -324,7 +324,7 @@ dependencies = [
  "chain-core",
  "chain-crypto",
  "const_format",
- "cryptoxide 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cryptoxide",
  "rand 0.8.4",
  "rand_core 0.6.3",
  "rayon",
@@ -446,13 +446,7 @@ dependencies = [
 [[package]]
 name = "cryptoxide"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129eabb7b0b78644a3a7e7cf220714aba47463bb281f69fa7a71ca5d12564cca"
-
-[[package]]
-name = "cryptoxide"
-version = "0.4.2"
-source = "git+https://github.com/typed-io/cryptoxide.git?branch=master#c953d1bfb22294d43098b8926e0ea215025d2061"
+source = "git+https://github.com/typed-io/cryptoxide.git#c953d1bfb22294d43098b8926e0ea215025d2061"
 
 [[package]]
 name = "curve25519-dalek"
@@ -515,7 +509,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb588f93c0d91b2f668849fd6d030cddb0b2e31f105963be189da5acdf492a21"
 dependencies = [
- "cryptoxide 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cryptoxide",
 ]
 
 [[package]]
@@ -622,7 +616,7 @@ dependencies = [
  "chain-addr",
  "chain-crypto",
  "chain-path-derivation",
- "cryptoxide 0.4.2 (git+https://github.com/typed-io/cryptoxide.git?branch=master)",
+ "cryptoxide",
  "ed25519-bip32",
  "hex",
  "quickcheck",
@@ -1165,7 +1159,7 @@ checksum = "8049cf85f0e715d6af38dde439cb0ccb91f67fb9f5f63c80f8b43e48356e1a3f"
 name = "symmetric-cipher"
 version = "0.5.0"
 dependencies = [
- "cryptoxide 0.4.2 (git+https://github.com/typed-io/cryptoxide.git?branch=master)",
+ "cryptoxide",
  "rand 0.8.4",
  "rand_chacha 0.3.1",
  "thiserror",
@@ -1372,7 +1366,7 @@ dependencies = [
  "chain-path-derivation",
  "chain-ser",
  "chain-time",
- "cryptoxide 0.4.2 (git+https://github.com/typed-io/cryptoxide.git?branch=master)",
+ "cryptoxide",
  "ed25519-bip32",
  "hashlink",
  "hdkeygen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,13 +99,14 @@ checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
 name = "bip39"
 version = "0.1.0"
 dependencies = [
- "cryptoxide 0.3.3",
+ "cryptoxide 0.4.2 (git+https://github.com/typed-io/cryptoxide.git?branch=master)",
  "hex",
  "quickcheck",
  "quickcheck_macros",
  "rand 0.8.4",
  "thiserror",
  "unicode-normalization",
+ "zeroize",
 ]
 
 [[package]]
@@ -178,7 +179,7 @@ source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#16
 dependencies = [
  "cbor_event",
  "chain-ser",
- "cryptoxide 0.4.2",
+ "cryptoxide 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-bip32",
 ]
 
@@ -237,7 +238,7 @@ dependencies = [
  "bech32 0.8.1",
  "chain-core",
  "chain-crypto",
- "cryptoxide 0.4.2",
+ "cryptoxide 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -254,7 +255,7 @@ version = "0.1.0"
 source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#1626503c539d31925fcd99c2683edc4f73ee15a6"
 dependencies = [
  "bech32 0.8.1",
- "cryptoxide 0.4.2",
+ "cryptoxide 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek-ng",
  "ed25519-bip32",
  "ed25519-dalek",
@@ -278,7 +279,7 @@ dependencies = [
  "chain-ser",
  "chain-time",
  "chain-vote",
- "cryptoxide 0.4.2",
+ "cryptoxide 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "imhamt",
  "rand 0.8.4",
@@ -323,7 +324,7 @@ dependencies = [
  "chain-core",
  "chain-crypto",
  "const_format",
- "cryptoxide 0.4.2",
+ "cryptoxide 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.4",
  "rand_core 0.6.3",
  "rayon",
@@ -444,15 +445,14 @@ dependencies = [
 
 [[package]]
 name = "cryptoxide"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c4fdc86023bc33b265f256ce8205329125b86c38a8a96e243a6a705b7230ec"
+checksum = "129eabb7b0b78644a3a7e7cf220714aba47463bb281f69fa7a71ca5d12564cca"
 
 [[package]]
 name = "cryptoxide"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129eabb7b0b78644a3a7e7cf220714aba47463bb281f69fa7a71ca5d12564cca"
+source = "git+https://github.com/typed-io/cryptoxide.git?branch=master#c953d1bfb22294d43098b8926e0ea215025d2061"
 
 [[package]]
 name = "curve25519-dalek"
@@ -515,7 +515,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb588f93c0d91b2f668849fd6d030cddb0b2e31f105963be189da5acdf492a21"
 dependencies = [
- "cryptoxide 0.4.2",
+ "cryptoxide 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -622,12 +622,13 @@ dependencies = [
  "chain-addr",
  "chain-crypto",
  "chain-path-derivation",
- "cryptoxide 0.3.3",
+ "cryptoxide 0.4.2 (git+https://github.com/typed-io/cryptoxide.git?branch=master)",
  "ed25519-bip32",
  "hex",
  "quickcheck",
  "quickcheck_macros",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -1164,10 +1165,11 @@ checksum = "8049cf85f0e715d6af38dde439cb0ccb91f67fb9f5f63c80f8b43e48356e1a3f"
 name = "symmetric-cipher"
 version = "0.5.0"
 dependencies = [
- "cryptoxide 0.3.3",
+ "cryptoxide 0.4.2 (git+https://github.com/typed-io/cryptoxide.git?branch=master)",
  "rand 0.8.4",
  "rand_chacha 0.3.1",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -1370,7 +1372,7 @@ dependencies = [
  "chain-path-derivation",
  "chain-ser",
  "chain-time",
- "cryptoxide 0.3.3",
+ "cryptoxide 0.4.2 (git+https://github.com/typed-io/cryptoxide.git?branch=master)",
  "ed25519-bip32",
  "hashlink",
  "hdkeygen",
@@ -1380,6 +1382,7 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -1607,18 +1610,18 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "50344758e2f40e3a1fcfc8f6f91aa57b5f8ebd8d27919fe6451f15aaaf9ee608"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.1.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ members = [
 
 [profile.release]
 lto = "yes"
+
+[patch.crates-io]
+cryptoxide = { git = "https://github.com/typed-io/cryptoxide.git" }

--- a/bip39/Cargo.toml
+++ b/bip39/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cryptoxide = "0.3.1"
+cryptoxide = { git = "https://github.com/typed-io/cryptoxide.git", branch = "master" }
 thiserror = { version = "1.0.13", default-features = false }
+zeroize = "1.5.3"
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/bip39/Cargo.toml
+++ b/bip39/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cryptoxide = { git = "https://github.com/typed-io/cryptoxide.git", branch = "master" }
+cryptoxide = "0.4.2"
 thiserror = { version = "1.0.13", default-features = false }
 zeroize = "1.5.3"
 

--- a/bip39/src/entropy.rs
+++ b/bip39/src/entropy.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 ///
 /// See module documentation for mode details about how to use
 /// `Entropy`.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, zeroize::ZeroizeOnDrop)]
 pub enum Entropy {
     Entropy9([u8; 12]),
     Entropy12([u8; 16]),
@@ -243,18 +243,5 @@ impl Deref for Entropy {
     type Target = [u8];
     fn deref(&self) -> &Self::Target {
         self.as_ref()
-    }
-}
-
-impl Drop for Entropy {
-    fn drop(&mut self) {
-        match self {
-            Entropy::Entropy9(b) => cryptoxide::util::secure_memset(b, 0),
-            Entropy::Entropy12(b) => cryptoxide::util::secure_memset(b, 0),
-            Entropy::Entropy15(b) => cryptoxide::util::secure_memset(b, 0),
-            Entropy::Entropy18(b) => cryptoxide::util::secure_memset(b, 0),
-            Entropy::Entropy21(b) => cryptoxide::util::secure_memset(b, 0),
-            Entropy::Entropy24(b) => cryptoxide::util::secure_memset(b, 0),
-        }
     }
 }

--- a/bip39/src/mnemonic.rs
+++ b/bip39/src/mnemonic.rs
@@ -1,3 +1,5 @@
+use zeroize::ZeroizeOnDrop;
+
 use crate::{dictionary, Error, Result, Type};
 use std::{fmt, ops::Deref, str};
 
@@ -33,7 +35,7 @@ pub struct Mnemonics(Vec<MnemonicIndex>);
 ///
 /// See the module documentation for more details about how to use it
 /// within the `chain_wallet` library.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, ZeroizeOnDrop)]
 pub struct MnemonicString(String);
 
 impl MnemonicString {
@@ -222,11 +224,5 @@ impl Drop for Mnemonics {
         for byte in self.0.iter_mut() {
             *byte = MnemonicIndex(0);
         }
-    }
-}
-
-impl Drop for MnemonicString {
-    fn drop(&mut self) {
-        unsafe { cryptoxide::util::secure_memset(self.0.as_mut_vec(), 0) }
     }
 }

--- a/bip39/src/seed.rs
+++ b/bip39/src/seed.rs
@@ -12,6 +12,7 @@ pub const SEED_SIZE: usize = 64;
 ///
 /// See the module documentation for more details about how to use it
 /// within the `chain_wallet` library.
+#[derive(zeroize::ZeroizeOnDrop)]
 pub struct Seed([u8; SEED_SIZE]);
 
 impl Seed {
@@ -109,11 +110,5 @@ impl Deref for Seed {
     type Target = [u8];
     fn deref(&self) -> &Self::Target {
         self.as_ref()
-    }
-}
-
-impl Drop for Seed {
-    fn drop(&mut self) {
-        cryptoxide::util::secure_memset(&mut self.0, 0)
     }
 }

--- a/hdkeygen/Cargo.toml
+++ b/hdkeygen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cryptoxide = { git = "https://github.com/typed-io/cryptoxide.git", branch = "master" }
+cryptoxide = "0.4.2"
 ed25519-bip32 = "0.4.0"
 bip39 = { path = "../bip39" }
 cbor_event = "^2.1.3"

--- a/hdkeygen/Cargo.toml
+++ b/hdkeygen/Cargo.toml
@@ -6,13 +6,14 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cryptoxide = "0.3.1"
+cryptoxide = { git = "https://github.com/typed-io/cryptoxide.git", branch = "master" }
 ed25519-bip32 = "0.4.0"
 bip39 = { path = "../bip39" }
 cbor_event = "^2.1.3"
 thiserror = { version = "1.0.13", default-features = false }
 chain-path-derivation = { path = "../chain-path-derivation" }
 hex = "0.4.2"
+zeroize = "1.5.3"
 
 chain-crypto = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 chain-addr = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }

--- a/hdkeygen/src/account.rs
+++ b/hdkeygen/src/account.rs
@@ -7,15 +7,14 @@
 
 use chain_addr::{Address, Discrimination, Kind};
 use chain_crypto::{AsymmetricKey, Ed25519, Ed25519Extended, PublicKey, SecretKey};
-use cryptoxide::ed25519;
+use cryptoxide::ed25519::{self, PRIVATE_KEY_LENGTH};
 use std::{
     convert::TryInto,
     fmt::{self, Display},
     str::FromStr,
 };
 
-pub use cryptoxide::ed25519::SEED_LENGTH;
-pub type Seed = [u8; SEED_LENGTH];
+pub type Seed = [u8; PRIVATE_KEY_LENGTH];
 
 pub struct Account<K: AsymmetricKey> {
     secret: SecretKey<K>,
@@ -167,7 +166,7 @@ mod tests {
 
     impl Arbitrary for Account<Ed25519> {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            let mut seed = [0; SEED_LENGTH];
+            let mut seed = [0; PRIVATE_KEY_LENGTH];
             g.fill_bytes(&mut seed);
             Self::from_seed(seed)
         }

--- a/hdkeygen/src/rindex/hdpayload.rs
+++ b/hdkeygen/src/rindex/hdpayload.rs
@@ -9,10 +9,7 @@
 //! payload and find the derivation path associated with it.
 //!
 use chain_path_derivation::{AnyScheme, Derivation, DerivationPath};
-use cryptoxide::{
-    chacha20poly1305::ChaCha20Poly1305, hmac::Hmac, pbkdf2::pbkdf2, sha2::Sha512,
-    util::secure_memset,
-};
+use cryptoxide::{chacha20poly1305::ChaCha20Poly1305, hmac::Hmac, pbkdf2::pbkdf2, sha2::Sha512};
 use ed25519_bip32::XPub;
 use thiserror::Error;
 
@@ -144,7 +141,7 @@ pub fn decode_derivation_path(buf: &[u8]) -> Option<DerivationPath<AnyScheme>> {
 }
 
 /// The key to encrypt and decrypt HD payload
-#[derive(Clone)]
+#[derive(Clone, zeroize::ZeroizeOnDrop)]
 pub struct HdKey([u8; HDKEY_SIZE]);
 impl HdKey {
     /// Create a new `HDKey` from an extended public key
@@ -188,11 +185,6 @@ impl HdKey {
         } else {
             Err(Error::CannotDecrypt)
         }
-    }
-}
-impl Drop for HdKey {
-    fn drop(&mut self) {
-        secure_memset(&mut self.0, 0)
     }
 }
 

--- a/symmetric-cipher/Cargo.toml
+++ b/symmetric-cipher/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.5.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cryptoxide = { git = "https://github.com/typed-io/cryptoxide.git", branch = "master" }
+cryptoxide = "0.4.2"
 rand = "0.8.3"
 thiserror = {version = "1.0.13", default-features = false}
 zeroize = "1.5.3"

--- a/symmetric-cipher/Cargo.toml
+++ b/symmetric-cipher/Cargo.toml
@@ -8,9 +8,10 @@ version = "0.5.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cryptoxide = "0.3.1"
+cryptoxide = { git = "https://github.com/typed-io/cryptoxide.git", branch = "master" }
 rand = "0.8.3"
 thiserror = {version = "1.0.13", default-features = false}
+zeroize = "1.5.3"
 
 [dev-dependencies]
 rand_chacha = "0.3.0"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cryptoxide = { git = "https://github.com/typed-io/cryptoxide.git", branch = "master" }
+cryptoxide = "0.4.2"
 ed25519-bip32 = "0.4.0"
 cbor_event = "^2.1.3"
 thiserror = { version = "1.0.13", default-features = false }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cryptoxide = "0.3.1"
+cryptoxide = { git = "https://github.com/typed-io/cryptoxide.git", branch = "master" }
 ed25519-bip32 = "0.4.0"
 cbor_event = "^2.1.3"
 thiserror = { version = "1.0.13", default-features = false }
@@ -16,6 +16,7 @@ hdkeygen = { path = "../hdkeygen" }
 hex = "0.4.2"
 itertools = "0.9"
 hashlink = "0.7.0"
+zeroize = "1.5.3"
 
 chain-time = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }
 chain-crypto = { git = "https://github.com/input-output-hk/chain-libs.git", branch = "master" }

--- a/wallet/src/password.rs
+++ b/wallet/src/password.rs
@@ -1,7 +1,6 @@
-use cryptoxide::util::secure_memset;
 use std::ops::{Deref, DerefMut};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, zeroize::ZeroizeOnDrop)]
 pub struct ScrubbedBytes(Vec<u8>);
 
 pub type Password = ScrubbedBytes;
@@ -33,11 +32,5 @@ impl Deref for ScrubbedBytes {
 impl DerefMut for ScrubbedBytes {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.deref_mut()
-    }
-}
-
-impl Drop for ScrubbedBytes {
-    fn drop(&mut self) {
-        secure_memset(&mut self.0, 0)
     }
 }

--- a/wallet/src/recovering/mod.rs
+++ b/wallet/src/recovering/mod.rs
@@ -105,7 +105,7 @@ impl RecoveryBuilder {
                 let entropy = self.entropy.clone().ok_or(RecoveryError::MissingEntropy)?;
                 let password = self.password.clone().unwrap_or_default();
 
-                let mut seed = [0u8; hdkeygen::account::SEED_LENGTH];
+                let mut seed = [0u8; cryptoxide::ed25519::PRIVATE_KEY_LENGTH];
                 keygen::generate_seed(&entropy, password.as_ref(), &mut seed);
 
                 Wallet::new_from_seed(seed)


### PR DESCRIPTION
I think we can switch to crates.io as soon as we have a release that
compiles for all our targets, in the meantime, this should enable us to
continue doing releases.

Since cryptoxide doesn't expose `secure_memset` anymore, this replaces
it with `zeroize`. Whether this is needed or not, I'm not sure, since
`secure_memset` was just a `for` loop anyway, we could just replace it
with a loop too, but I don't see any problems with `zeroize`.