### PR TITLE
strip symbols in release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 
 [profile.release]
 lto = "yes"
+strip = "symbols"
 
 [patch.crates-io]
 cryptoxide = { git = "https://github.com/typed-io/cryptoxide.git" }


### PR DESCRIPTION
This seems to reduce the size of the shared android library by half (2.5M to 1.2M), which is not a lot, but may be nice for the mobile targets at least. 

Just as a note, while android strips native libraries by default, it does not seem to be able to do it with this lib (it shows a warning when building).

All of this probably applies for ios too, but I haven't measured that.